### PR TITLE
Fix conditional for handling external order status

### DIFF
--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -429,16 +429,15 @@ export class OrdersService {
         order => order.externalId === existingOrder.externalId
       )
 
-      if (
-        externalOrder == null ||
-        existingOrder.status === externalOrder.status
-      ) {
-        continue
-      }
+      if (externalOrder == null) continue
+
+      const mappedStatus = externalOrderStatusMapper(externalOrder.status)
+
+      if (existingOrder.status === mappedStatus) continue
 
       updatedOrders.push({
         ...existingOrder,
-        status: externalOrderStatusMapper(externalOrder.status)
+        status: mappedStatus
       })
     }
 


### PR DESCRIPTION
The conditional that was changed didn't take into account mapped statuses so it was skipping some of them.