### PR TITLE
Add timeout error to ActiveMQ/Engine responses

### DIFF
--- a/src/common/classes/timeout-mqtt-client.ts
+++ b/src/common/classes/timeout-mqtt-client.ts
@@ -1,0 +1,25 @@
+import { GatewayTimeoutException } from '@nestjs/common'
+import { ClientMqtt } from '@nestjs/microservices'
+import { Observable, TimeoutError, throwError } from 'rxjs'
+import { timeout, catchError } from 'rxjs/operators'
+import { ENGINE_RESPONSE_TIMEOUT } from '../constants/engine.constant'
+
+export class TimeoutClientMqtt extends ClientMqtt {
+  send<TResult = any, TInput = any> (
+    pattern: any,
+    data: TInput
+  ): Observable<TResult> {
+    return super.send(pattern, data).pipe(
+      timeout(ENGINE_RESPONSE_TIMEOUT),
+      catchError(err => {
+        if (err instanceof TimeoutError) {
+          return throwError(
+            new GatewayTimeoutException('The engine did not respond in time')
+          )
+        }
+
+        return throwError(err)
+      })
+    )
+  }
+}

--- a/src/common/constants/engine.constant.ts
+++ b/src/common/constants/engine.constant.ts
@@ -1,0 +1,1 @@
+export const ENGINE_RESPONSE_TIMEOUT = 1000 * 5 // 5 seconds

--- a/src/common/providers/activemq-client-options.provider.ts
+++ b/src/common/providers/activemq-client-options.provider.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import {
   ClientProvider,
-  ClientsModuleOptionsFactory,
-  Transport
+  ClientsModuleOptionsFactory
 } from '@nestjs/microservices'
+import { TimeoutClientMqtt } from '../classes/timeout-mqtt-client'
 
 @Injectable()
 export class ActiveMQClientOptions implements ClientsModuleOptionsFactory {
@@ -12,7 +12,7 @@ export class ActiveMQClientOptions implements ClientsModuleOptionsFactory {
 
   async createClientOptions (): Promise<ClientProvider> {
     return {
-      transport: Transport.MQTT,
+      customClass: TimeoutClientMqtt,
       options: {
         ...this.configService.get('activeMQ')
       }


### PR DESCRIPTION
Closes #38

Current timeout is 5 seconds (see `src/common/constants/engine.constant.ts`).

@jperezg let me know if 5 seconds is little or enough.