### PR TITLE
Add practice parameter to integrations search

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -266,6 +266,12 @@ export class AdminController {
       })
     }
 
+    if (params.search !== undefined) {
+      queryBuilder.andWhere('practice.name LIKE :search', {
+        search: `%${params.search}%`,
+      })
+    }
+
     const [data, total] = await queryBuilder.getManyAndCount()
 
     return {

--- a/src/providers/dtos/integrations-search.dto.ts
+++ b/src/providers/dtos/integrations-search.dto.ts
@@ -21,4 +21,8 @@ export class IntegrationsSearch extends PaginationDto {
   @IsOptional()
   @IsString()
   practices: string
+
+  @IsOptional()
+  @IsString()
+  search: string
 }


### PR DESCRIPTION
  - Adds a "Search by practice..." text input to the integrations table toolbar
  - Wires the search query through getIntegrations in the API client to the backend
  - Backend filters integrations by `practice.name LIKE :search` via a new search param in IntegrationsSearch DTO and AdminController
 
 Related to https://github.com/nominal-systems/dmi-api-admin-ui/issues/96