### PR TITLE
Add search functionality to events query

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -181,6 +181,14 @@ export class AdminController {
     if (query.endDate !== undefined) {
       options.createdAt = { ...options.createdAt, $lte: new Date(query.endDate) }
     }
+    if (query.search !== undefined) {
+      const matchingPractices = await this.practicesRepository
+        .createQueryBuilder('practice')
+        .where('practice.name LIKE :search', { search: `%${query.search}%` })
+        .select('practice.id')
+        .getMany()
+      options.practiceId = { $in: matchingPractices.map((p) => p.id) }
+    }
     const { page, limit } = query
 
     const data = await this.eventsService.find(options, { page, limit })

--- a/src/admin/dtos/events-query.dto.ts
+++ b/src/admin/dtos/events-query.dto.ts
@@ -16,4 +16,7 @@ export class EventsQueryDto extends IntersectionType(DateRangeDto, PaginationDto
   @IsOptional()
   @Transform(({ value }) => value.split(','))
   types?: string[]
+
+  @IsOptional()
+  search?: string
 }


### PR DESCRIPTION
  Extended `GET /admin/events` to support filtering by practice name.                                                                                                                                            
   
  | File | Change |                                                                                                                                                                                              
  |------|--------|
  | `src/admin/dtos/events-query.dto.ts` | Added optional `search` field to `EventsQueryDto` |
  | `src/admin/admin.controller.ts` | When `search` is provided, queries MySQL for practices matching the term (`LIKE %term%`), then filters MongoDB events by the resulting practice IDs |                      
                                                                                                                                                                                                                 
  > No new indexes required — `events.practiceId` is already indexed in MongoDB.                                                                                                                                 

Closes https://github.com/nominal-systems/dmi-api-admin-ui/issues/94