### PR TITLE
Add patient/client validation to handleExternalOrderResults

### DIFF
--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -590,6 +590,16 @@ export class OrdersService {
 
       try {
         const order = await this.findOneByExternalId(externalOrderId)
+
+        // Validate that the existing order matches the incoming result data
+        if (result.order != null && order.patient?.name) {
+          const extractedOrder = ProviderResultUtils.extractOrderFromOrphanResult(result, integrationId)
+          if (!ProviderResultUtils.isMatchingOrder(order, extractedOrder)) {
+            this.logger.warn(`Skipping order update for ${order.id}: patient/client mismatch (externalId=${externalOrderId})`)
+            continue
+          }
+        }
+
         const updated = await this.updateOrderFromResults(order, result)
         if (updated) {
           updatedOrders.push(order)


### PR DESCRIPTION
## Summary
- `OrdersService.handleExternalOrderResults()` was updating orders matched by `externalId` without validating patient/client data, allowing orphan results with placeholder IDs (e.g., `requisitionId: "12345"`) to incorrectly update unrelated orders
- Added `ProviderResultUtils.isMatchingOrder()` validation before `updateOrderFromResults()`, consistent with the existing fix in `ReportsService.handleExternalResults()` (PR #277)
- Validation only runs when the existing order already has patient data, to avoid blocking legitimate cases where orders are created without patient info and filled in by results

Closes #285

## Test plan
- [x] All existing unit tests pass (orders: 20/20, reports: 24/24, provider-result-utils: 12/12)
- [x] Deploy to staging and verify orphan results with colliding `externalId` no longer update the wrong order's status
- [ ] Verify that normal result flows (non-orphan, orders without patient data) continue to work correctly