### PR TITLE
fix: set partition key on Event Hub events to preserve ordering

### DIFF
--- a/src/events/services/event-subscription.service.ts
+++ b/src/events/services/event-subscription.service.ts
@@ -103,7 +103,9 @@ export class EventSubscriptionService {
         const credential = new AzureNamedKeyCredential(opts.sa_key_name, opts.sa_key_value)
         const namespace = [opts.hub_namespace, '.servicebus.windows.net'].join('')
         const producer = new EventHubProducerClient(namespace, opts.hub_name, credential)
-        const eventDataBatch = await producer.createBatch()
+        const eventData: Record<string, any> = event.data ?? {}
+        const partitionKey: string | undefined = eventData.reportId ?? eventData.orderId ?? event.accessionId
+        const eventDataBatch = await producer.createBatch({ ...(partitionKey != null && { partitionKey }) })
         eventDataBatch.tryAdd({ body: event })
         await producer.sendBatch(eventDataBatch)
         await producer.close()


### PR DESCRIPTION
## Summary

- Events published to Azure Event Hub via `EventSubscriptionService.notifySubscriptions()` were sent **without a `partitionKey`**, causing Event Hub to round-robin events across partitions. This meant events for the same report/order could be processed out of order by downstream consumers, resulting in duplicate or inconsistent records on the consumer side.
- Derives a `partitionKey` from the event payload — `reportId` for report events, `orderId` for order events, `accessionId` as fallback — so all events for the same entity route to the same partition.

Closes #287

## Test plan

- [ ] Deploy to UAT and publish a `report:created` followed by a `report:updated` for the same report. Verify both events land on the same Event Hub partition (check `PartitionId` in consumer logs or Event Hub metrics).
- [ ] Publish events for different reports and verify they distribute across partitions (not all on one).
- [ ] Publish an `order:created` event and confirm `orderId` is used as the partition key.
- [ ] Verify that events with no `reportId` or `orderId` fall back to `accessionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)