### PR TITLE
fix: make MapAntechRefs migration idempotent (#289)

### DIFF
--- a/test/e2e/map-antech-refs-migration.e2e-spec.ts
+++ b/test/e2e/map-antech-refs-migration.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { Connection, createConnection } from 'typeorm'
+import * as path from 'path'
+
+const TEST_DB = 'dmi_map_antech_refs_test'
+
+const baseConfig = {
+  type: 'mysql' as const,
+  host: process.env.DATABASE_HOST ?? 'localhost',
+  port: Number(process.env.DATABASE_PORT ?? 3306),
+  username: process.env.DATABASE_USERNAME ?? 'root',
+  password: process.env.DATABASE_PASSWORD ?? 'asdf1234',
+}
+
+describe('MapAntechRefs1699995684080 idempotency (regression for #289)', () => {
+  let adminConnection: Connection | null = null
+  let testConnection: Connection | null = null
+  let canRun = false
+
+  beforeAll(async () => {
+    try {
+      adminConnection = await createConnection({
+        ...baseConfig,
+        name: 'map-antech-refs-admin',
+      })
+      await adminConnection.query(`DROP DATABASE IF EXISTS \`${TEST_DB}\``)
+      await adminConnection.query(`CREATE DATABASE \`${TEST_DB}\``)
+      canRun = true
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[map-antech-refs.e2e] MySQL not reachable, skipping. Reason: ${(err as Error).message}`,
+      )
+    }
+  }, 60_000)
+
+  afterAll(async () => {
+    if (testConnection?.isConnected) {
+      await testConnection.close()
+    }
+    if (adminConnection?.isConnected) {
+      if (canRun) {
+        await adminConnection.query(`DROP DATABASE IF EXISTS \`${TEST_DB}\``)
+      }
+      await adminConnection.close()
+    }
+  }, 60_000)
+
+  it(
+    'should not throw when re-run after its migrations record is removed',
+    async () => {
+      if (!canRun) {
+        return
+      }
+
+      testConnection = await createConnection({
+        ...baseConfig,
+        database: TEST_DB,
+        name: 'map-antech-refs-test',
+        migrations: [path.join(__dirname, '../../src/migrations/*.{ts,js}')],
+        synchronize: false,
+      })
+
+      // First run — applies all migrations, including MapAntechRefs.
+      await testConnection.runMigrations({ transaction: 'all' })
+
+      const [{ c: refsBefore }] = await testConnection.query(
+        'SELECT COUNT(*) AS c FROM `ref`',
+      )
+      const [{ c: providerRefsBefore }] = await testConnection.query(
+        'SELECT COUNT(*) AS c FROM `provider_ref`',
+      )
+      expect(Number(refsBefore)).toBeGreaterThan(0)
+      expect(Number(providerRefsBefore)).toBeGreaterThan(0)
+
+      // Reproduce the bug scenario: data is in place but the migrations
+      // table no longer remembers that MapAntechRefs ran.
+      await testConnection.query(
+        "DELETE FROM `migrations` WHERE `name` = 'MapAntechRefs1699995684080'",
+      )
+
+      // The migration must now be safely re-runnable.
+      await expect(
+        testConnection.runMigrations({ transaction: 'all' }),
+      ).resolves.not.toThrow()
+
+      // And it must not have duplicated any rows.
+      const [{ c: refsAfter }] = await testConnection.query(
+        'SELECT COUNT(*) AS c FROM `ref`',
+      )
+      const [{ c: providerRefsAfter }] = await testConnection.query(
+        'SELECT COUNT(*) AS c FROM `provider_ref`',
+      )
+      expect(Number(refsAfter)).toBe(Number(refsBefore))
+      expect(Number(providerRefsAfter)).toBe(Number(providerRefsBefore))
+    },
+    600_000,
+  )
+})


### PR DESCRIPTION
## Summary
Makes the `MapAntechRefs1699995684080` migration idempotent so it can safely recover from partial runs (e.g., k8s SIGKILL mid-migration) without throwing `Duplicate entry` errors.

## Changes
- **ref table inserts:** Added `ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)` to both `INSERT INTO ref` statements. This ensures `insertId` returns the existing row's ID when a duplicate is encountered, keeping the downstream `provider_ref` mapping logic intact.
- **provider_ref inserts:** Replaced per-iteration `SELECT` with a single pre-load into an in-memory `Set`. This avoids O(n²) full table scans during the ~50k mappings loop, keeping migration runtime fast and reducing the crash window.

## Deployment safety
- TypeORM tracks migrations by name only (no checksum). Environments where `MapAntechRefs1699995684080` already ran successfully are unaffected — the modified `up()` body only executes if the migration is re-run, which is precisely the bug scenario this PR addresses.
- No schema change, no data migration. Pure logic change inside `up()`.
- Rollback: revert this PR. No DB-side rollback needed.

## Testing
- Reproduced the issue locally by creating a fresh DB, running migrations, deleting the `MapAntechRefs` record from `migrations`, and re-running — migration completes successfully without duplicates.
- `map-antech-refs-migration.e2e-spec.ts` (regression test for #289) passes.
- All e2e tests pass: `npm run test:e2e`.

## Running the regression test
- `npm run test:e2e -- --testPathPattern=map-antech-refs-migration`
- Requires a reachable MySQL (uses `.env` credentials). Auto-skips with a warning if MySQL isn't reachable, so CI environments without a DB aren't affected.
- Runtime ~60s (the migration inserts ~50k rows, and the test runs it twice).
- Uses a dedicated test DB (`dmi_map_antech_refs_test`) that the test creates and drops. Doesn't touch your dev DB.

## Related
- Fixes #289
- Original report: `Duplicate entry '2d19e599-bd6b-11eb-a52c-302432eba3e9' for key 'IDX_6309ffe95af9503285bdb8480f'`