### PR TITLE
feat: persist integrationId on internal events and external requests

### DIFF
--- a/src/common/utils/ieMessageBuilder.ts
+++ b/src/common/utils/ieMessageBuilder.ts
@@ -6,6 +6,7 @@ interface IntergrationEngineOutgoingMessageData {
   integrationOptions?: any
   payload?: any
   autoSubmitOrder?: boolean
+  integrationId?: string
 }
 
 interface IntegrationEngineResultsData {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -261,6 +261,7 @@ export class OrdersService {
           integrationOptions,
           providerConfiguration: configurationOptions,
           autoSubmitOrder,
+          integrationId: integration.id,
         },
       })
       this.logger.log(`Sending '${messagePattern}' to '${providerId}' provider`)

--- a/src/providers/dtos/provider-raw-data.dto.ts
+++ b/src/providers/dtos/provider-raw-data.dto.ts
@@ -9,6 +9,10 @@ export class ProviderRawDataDto {
   @IsString()
   accessionIds?: string[]
 
+  @IsOptional()
+  @IsString()
+  integrationId?: string
+
   @IsNotEmpty()
   @IsNumber()
   status: number

--- a/src/providers/entities/provider-external-requests.entity.ts
+++ b/src/providers/entities/provider-external-requests.entity.ts
@@ -13,6 +13,9 @@ export class ProviderExternalRequests {
     accessionIds?: string[]
 
     @Prop({ index: true })
+    integrationId?: string
+
+    @Prop({ index: true })
     status: number
 
     @Prop()

--- a/src/providers/services/providers.service.ts
+++ b/src/providers/services/providers.service.ts
@@ -337,7 +337,7 @@ export class ProvidersService {
   async saveProviderRawData (
     data: ProviderRawDataDto
   ): Promise<void> {
-    const { body, url, method, provider, status, payload, headers } = data
+    const { body, url, method, provider, status, payload, headers, integrationId } = data
 
     let accessionIds
     if (data.accessionIds !== undefined) {
@@ -348,6 +348,7 @@ export class ProvidersService {
       createdAt: new Date(),
       provider,
       accessionIds,
+      integrationId,
       status,
       method,
       url,


### PR DESCRIPTION
Closes nominal-systems/dmi-api-admin-ui#93

- Adds \integrationId\ field to outgoing integration engine messages (ieMessageBuilder.ts)
- Threads integration.id through OrdersService into the message payload
- Adds integrationId to ProviderRawDataDto and ProviderExternalRequests entity
- Persists integrationId when saving provider raw data in ProvidersService

This change is safe to merge before integrations emit the field — it will simply be undefined until then.