### PR TITLE
Add integration and practice context to external requests

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -62,7 +62,7 @@ import { ExternalRequestsQueryDto } from './dtos/external-requests-query.dto'
 import { ExternalRequestsStatsDto } from './dtos/external-requests-stats.dto'
 import { EventsQueryDto } from './dtos/events-query.dto'
 import { EventsStatsDto } from './dtos/events-stats.dto'
-import { PracticesQueryDto } from '../practices/dto/practice-search-query-params.dto'
+import { AdminPracticesQueryDto } from './dtos/practices-query.dto'
 import { OrdersStatsDto } from './dtos/orders-stats.dto'
 import {
   InternalEventLoggingService,
@@ -775,7 +775,7 @@ export class AdminController {
 
   @Get('/practices')
   async getPractices (
-    @Query() query: PracticesQueryDto & PaginationDto,
+    @Query() query: AdminPracticesQueryDto,
   ): Promise<PaginationResult<Practice>> {
     const take = query.limit !== undefined ? query.limit : PAGINATION_PAGE_LIMIT
     const skip = query.page !== undefined ? (query.page - 1) * take : 0

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -721,6 +721,12 @@ export class AdminController {
     if (query.method !== undefined) {
       options.method = { $in: query.method }
     }
+    if (query.integrationId !== undefined) {
+      options.integrationId = { $in: query.integrationId }
+    }
+    if (query.practiceId !== undefined) {
+      options.practiceId = { $in: query.practiceId }
+    }
 
     if (query.startDate !== undefined) {
       options.createdAt = { $gte: new Date(query.startDate) }
@@ -747,6 +753,12 @@ export class AdminController {
     }
     if (query.endDate !== undefined) {
       options.createdAt = { ...options.createdAt, $lte: new Date(query.endDate) }
+    }
+    if (query.integrationId !== undefined) {
+      options.integrationId = { $in: query.integrationId }
+    }
+    if (query.practiceId !== undefined) {
+      options.practiceId = { $in: query.practiceId }
     }
     options.status = {
       $gte: 400,

--- a/src/admin/dtos/external-requests-query.dto.ts
+++ b/src/admin/dtos/external-requests-query.dto.ts
@@ -12,4 +12,10 @@ export class ExternalRequestsQueryDto extends IntersectionType(DateRangeDto, Pag
 
   @Transform(({ value }) => value.split(','))
   status?: string[]
+
+  @Transform(({ value }) => value.split(','))
+  integrationId?: string[]
+
+  @Transform(({ value }) => value.split(','))
+  practiceId?: string[]
 }

--- a/src/admin/dtos/external-requests-stats.dto.ts
+++ b/src/admin/dtos/external-requests-stats.dto.ts
@@ -1,3 +1,10 @@
 import { DateRangeDto } from './date-range.dto'
+import { Transform } from 'class-transformer'
 
-export class ExternalRequestsStatsDto extends DateRangeDto {}
+export class ExternalRequestsStatsDto extends DateRangeDto {
+  @Transform(({ value }) => value.split(','))
+  integrationId?: string[]
+
+  @Transform(({ value }) => value.split(','))
+  practiceId?: string[]
+}

--- a/src/admin/dtos/practices-query.dto.ts
+++ b/src/admin/dtos/practices-query.dto.ts
@@ -1,0 +1,8 @@
+import { IntersectionType } from '@nestjs/mapped-types'
+import { PaginationDto } from '../../common/dtos/pagination.dto'
+import { PracticesQueryDto } from '../../practices/dto/practice-search-query-params.dto'
+
+export class AdminPracticesQueryDto extends IntersectionType(
+  PracticesQueryDto,
+  PaginationDto,
+) {}

--- a/src/common/utils/ieMessageBuilder.ts
+++ b/src/common/utils/ieMessageBuilder.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { IE_MESSAGE_VERSION } from '../constants/api.constant'
 
 interface IntergrationEngineOutgoingMessageData {
+  integrationId?: string
   providerConfiguration?: any
   integrationOptions?: any
   payload?: any

--- a/src/integrations/integrations.service.ts
+++ b/src/integrations/integrations.service.ts
@@ -209,6 +209,7 @@ export class IntegrationsService {
           resource: Resource.Integration,
           operation: Operation.Remove,
           data: {
+            integrationId: integration.id,
             payload: {
               integrationId: integration.id,
             },
@@ -236,6 +237,7 @@ export class IntegrationsService {
         resource: Resource.Integration,
         operation: Operation.Create,
         data: {
+          integrationId,
           integrationOptions: integrationOptions,
           providerConfiguration: providerConfiguration.configurationOptions,
           payload: {
@@ -260,6 +262,7 @@ export class IntegrationsService {
       resource: Resource.Integration,
       operation: Operation.Update,
       data: {
+        integrationId,
         integrationOptions: integrationOptions,
         providerConfiguration: providerConfiguration.configurationOptions,
         payload: {
@@ -278,6 +281,7 @@ export class IntegrationsService {
         resource: Resource.Integration,
         operation: Operation.Test,
         data: {
+          integrationId: integration.id,
           integrationOptions: integration.integrationOptions,
           providerConfiguration: integration.providerConfiguration.configurationOptions,
           payload: null,

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -173,7 +173,7 @@ export class OrdersService {
   ): Promise<any> {
     const {
       externalId,
-      integration: { providerConfiguration, integrationOptions },
+      integration: { id: integrationId, providerConfiguration, integrationOptions },
     } = await this.findOne({
       id: orderId,
       options: {
@@ -189,6 +189,7 @@ export class OrdersService {
       resource: 'orders',
       operation: format === 'json' ? 'results' : 'results.pdf',
       data: {
+        integrationId,
         payload: { id: externalId },
         integrationOptions,
         providerConfiguration: providerConfiguration.configurationOptions,
@@ -257,6 +258,7 @@ export class OrdersService {
         resource: 'orders',
         operation: 'create',
         data: {
+          integrationId: integration.id,
           payload: providerOrder,
           integrationOptions,
           providerConfiguration: configurationOptions,
@@ -341,7 +343,7 @@ export class OrdersService {
     })
     const {
       externalId,
-      integration: { providerConfiguration, integrationOptions },
+      integration: { id: integrationId, providerConfiguration, integrationOptions },
     } = order
 
     if (organization.id !== providerConfiguration.organizationId) {
@@ -353,6 +355,7 @@ export class OrdersService {
       resource: 'orders',
       operation: 'cancel',
       data: {
+        integrationId,
         providerConfiguration: configurationOptions,
         integrationOptions,
         payload: {
@@ -409,13 +412,14 @@ export class OrdersService {
 
     const {
       externalId,
-      integration: { providerConfiguration, integrationOptions },
+      integration: { id: integrationId, providerConfiguration, integrationOptions },
     } = order
 
     const { message, messagePattern } = ieMessageBuilder(providerConfiguration.providerId, {
       resource: 'orders',
       operation: 'tests.add',
       data: {
+        integrationId,
         providerConfiguration: providerConfiguration.configurationOptions,
         integrationOptions,
         payload: {
@@ -461,13 +465,14 @@ export class OrdersService {
 
     const {
       externalId,
-      integration: { providerConfiguration, integrationOptions },
+      integration: { id: integrationId, providerConfiguration, integrationOptions },
     } = order
 
     const { message, messagePattern } = ieMessageBuilder(providerConfiguration.providerId, {
       resource: 'orders',
       operation: 'tests.cancel',
       data: {
+        integrationId,
         providerConfiguration: providerConfiguration.configurationOptions,
         integrationOptions,
         payload: {
@@ -654,7 +659,7 @@ export class OrdersService {
       const {
         externalId,
         requisitionId,
-        integration: { providerConfiguration, integrationOptions },
+        integration: { id: integrationId, providerConfiguration, integrationOptions },
       } = order
 
       if (providerConfiguration.organizationId !== organization.id) {
@@ -666,6 +671,7 @@ export class OrdersService {
         resource: EventNamespace.ORDERS,
         operation: Operation.Manifest,
         data: {
+          integrationId,
           providerConfiguration: configurationOptions,
           integrationOptions,
           payload: {
@@ -716,12 +722,14 @@ export class OrdersService {
     externalId: string,
     providerConfiguration: ProviderConfiguration,
     integrationOptions: IntegrationOptions,
+    integrationId?: string,
   ): Promise<ExternalOrder> {
     this.logger.debug(`Getting order ${externalId} from ${providerConfiguration.providerId}`)
     const { message, messagePattern } = ieMessageBuilder(providerConfiguration.providerId, {
       resource: Resource.Orders,
       operation: Operation.Get,
       data: {
+        integrationId,
         payload: { id: externalId },
         integrationOptions,
         providerConfiguration: providerConfiguration.configurationOptions,

--- a/src/providers/dtos/provider-raw-data.dto.ts
+++ b/src/providers/dtos/provider-raw-data.dto.ts
@@ -9,6 +9,10 @@ export class ProviderRawDataDto {
   @IsString()
   accessionIds?: string[]
 
+  @IsOptional()
+  @IsString()
+  integrationId?: string
+
   @IsNotEmpty()
   @IsNumber()
   status: number

--- a/src/providers/entities/provider-external-requests.entity.ts
+++ b/src/providers/entities/provider-external-requests.entity.ts
@@ -13,6 +13,12 @@ export class ProviderExternalRequests {
     accessionIds?: string[]
 
     @Prop({ index: true })
+    integrationId?: string
+
+    @Prop({ index: true })
+    practiceId?: string
+
+    @Prop({ index: true })
     status: number
 
     @Prop()

--- a/src/providers/services/providers.service.spec.ts
+++ b/src/providers/services/providers.service.spec.ts
@@ -35,7 +35,7 @@ const providerOptionRepositoryMock = {}
 
 describe('ProvidersService', () => {
   let service: ProvidersService
-  // let integrationsService: IntegrationsService
+  let integrationsService: IntegrationsService
   // let clientProxy: ClientProxy
   let providerExternalRequestsModel: Model<ProviderExternalRequestDocument>
 
@@ -74,7 +74,7 @@ describe('ProvidersService', () => {
     }).compile()
 
     service = module.get<ProvidersService>(ProvidersService)
-    // integrationsService = module.get<IntegrationsService>(IntegrationsService)
+    integrationsService = module.get<IntegrationsService>(IntegrationsService)
     // clientProxy = module.get<ClientProxy>(ClientProxy)
     providerExternalRequestsModel = module.get<Model<any>>(getModelToken('ProviderExternalRequests'))
   })
@@ -163,6 +163,95 @@ describe('ProvidersService', () => {
       )
 
       createSpy.mockRestore()
+    })
+    it('should resolve and save the practiceId when integrationId is present', async () => {
+      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const findOneSpy = jest.spyOn(integrationsService, 'findOne').mockResolvedValue({
+        id: 'integration-1',
+        practiceId: 'practice-1'
+      } as unknown as Integration)
+
+      const data = {
+        headers: { 'Content-Type': 'application/json' },
+        body: { some: 'data' },
+        url: 'http://example.com',
+        method: 'GET',
+        provider: 'test-provider',
+        status: 200,
+        integrationId: 'integration-1',
+        payload: undefined
+      }
+
+      await service.saveProviderRawData(data)
+
+      expect(findOneSpy).toHaveBeenCalledWith({
+        id: 'integration-1',
+        options: { withDeleted: true }
+      })
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrationId: 'integration-1',
+          practiceId: 'practice-1'
+        }),
+        expect.any(Function)
+      )
+
+      createSpy.mockRestore()
+      findOneSpy.mockRestore()
+    })
+    it('should cache the integration → practice lookup', async () => {
+      const findOneSpy = jest.spyOn(integrationsService, 'findOne').mockResolvedValue({
+        id: 'integration-1',
+        practiceId: 'practice-1'
+      } as unknown as Integration)
+
+      const data = {
+        headers: {},
+        body: {},
+        url: 'http://example.com',
+        method: 'GET',
+        provider: 'test-provider',
+        status: 200,
+        integrationId: 'integration-1',
+        payload: undefined
+      }
+
+      await service.saveProviderRawData(data)
+      await service.saveProviderRawData(data)
+
+      expect(findOneSpy).toHaveBeenCalledTimes(1)
+
+      findOneSpy.mockRestore()
+    })
+    it('should save the integrationId without practiceId when the integration cannot be resolved', async () => {
+      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const findOneSpy = jest.spyOn(integrationsService, 'findOne')
+        .mockRejectedValue(new Error('The integration was not found'))
+
+      const data = {
+        headers: {},
+        body: {},
+        url: 'http://example.com',
+        method: 'GET',
+        provider: 'test-provider',
+        status: 200,
+        integrationId: 'missing-integration',
+        payload: undefined
+      }
+
+      await service.saveProviderRawData(data)
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrationId: 'missing-integration'
+        }),
+        expect.any(Function)
+      )
+      const saved = createSpy.mock.calls[0][0] as any
+      expect(saved.practiceId).toBeUndefined()
+
+      createSpy.mockRestore()
+      findOneSpy.mockRestore()
     })
   })
   describe('checkLabRequisitionParameters()', () => {

--- a/src/providers/services/providers.service.ts
+++ b/src/providers/services/providers.service.ts
@@ -33,6 +33,7 @@ import { isNullOrEmpty } from '../../common/utils/shared.utils'
 @Injectable()
 export class ProvidersService {
   private readonly logger = new Logger(ProvidersService.name)
+  private readonly practiceIdCache = new Map<string, string>()
 
   constructor (
     @InjectRepository(Provider)
@@ -344,7 +345,7 @@ export class ProvidersService {
   async saveProviderRawData (
     data: ProviderRawDataDto
   ): Promise<void> {
-    const { body, url, method, provider, status, payload, headers } = data
+    const { body, url, method, provider, status, payload, headers, integrationId } = data
 
     let accessionIds
     if (data.accessionIds !== undefined) {
@@ -360,6 +361,14 @@ export class ProvidersService {
       url,
       headers: nestKeys(headers),
       body: nestKeys(body) // Nest keys to ensure MongoDB safety
+    }
+
+    if (integrationId !== undefined) {
+      rawData.integrationId = integrationId
+      const practiceId = await this.resolvePracticeId(integrationId)
+      if (practiceId !== undefined) {
+        rawData.practiceId = practiceId
+      }
     }
 
     if (payload !== undefined) {
@@ -381,6 +390,27 @@ export class ProvidersService {
         })
       }
     })
+  }
+
+  // The integration → practice relationship is immutable, so resolved pairs
+  // are cached for the lifetime of the process.
+  private async resolvePracticeId (integrationId: string): Promise<string | undefined> {
+    const cached = this.practiceIdCache.get(integrationId)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    try {
+      const integration = await this.integrationsService.findOne({
+        id: integrationId,
+        options: { withDeleted: true }
+      })
+      this.practiceIdCache.set(integrationId, integration.practiceId)
+      return integration.practiceId
+    } catch (error) {
+      this.logger.warn(`Could not resolve practice for integration ${integrationId}`)
+      return undefined
+    }
   }
 
   async findAllExternalRequests (

--- a/src/providers/services/providers.service.ts
+++ b/src/providers/services/providers.service.ts
@@ -88,6 +88,7 @@ export class ProvidersService {
       resource: Resource.Services,
       operation: Operation.List,
       data: {
+        integrationId,
         integrationOptions,
         providerConfiguration: configurationOptions,
         payload: labRequisitionParameters
@@ -118,6 +119,7 @@ export class ProvidersService {
       resource: Resource.Services,
       operation: Operation.Get,
       data: {
+        integrationId,
         integrationOptions,
         providerConfiguration: configurationOptions,
         payload: { labRequisitionParameters, code }
@@ -144,6 +146,7 @@ export class ProvidersService {
       resource: Resource.Devices,
       operation: Operation.List,
       data: {
+        integrationId,
         integrationOptions,
         providerConfiguration: configurationOptions
       }
@@ -175,6 +178,7 @@ export class ProvidersService {
       resource: 'refs',
       operation: 'version',
       data: {
+        integrationId,
         integrationOptions,
         providerConfiguration: configurationOptions
       }
@@ -201,6 +205,7 @@ export class ProvidersService {
       resource: 'breeds',
       operation: 'list',
       data: {
+        integrationId,
         integrationOptions,
         providerConfiguration: configurationOptions
       }
@@ -227,6 +232,7 @@ export class ProvidersService {
       resource: 'sexes',
       operation: 'list',
       data: {
+        integrationId,
         integrationOptions,
         providerConfiguration: configurationOptions
       }
@@ -253,6 +259,7 @@ export class ProvidersService {
       resource: 'species',
       operation: 'list',
       data: {
+        integrationId,
         integrationOptions,
         providerConfiguration: configurationOptions
       }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -152,7 +152,7 @@ export class ReportsService {
     const nonExistingOrderExternalIds = arrayDiff(nonExistingReportExternalOrderIds, nonExistingReportOrders.map(order => order.externalId))
     for (const externalOrderId of nonExistingOrderExternalIds) {
       try {
-        const externalOrder = await this.ordersService.getOrderFromProvider(externalOrderId, integration.providerConfiguration, integration.integrationOptions)
+        const externalOrder = await this.ordersService.getOrderFromProvider(externalOrderId, integration.providerConfiguration, integration.integrationOptions, integration.id)
         if (externalOrder == null) {
           this.logger.warn(`Order from provider not found -> External ID: ${externalOrderId}`)
           continue


### PR DESCRIPTION
Part of #302 (PR 2 of the plan: emitter + receiver in a single PR, reviewable commit by commit).

dmi-api deploys as a single service, so both sides ship together. This PR does **not** depend on `dmi-engine-common` 1.3.0 (nominal-systems/dmi-engine-common#25): the DTO and Mongo schema are local, and `common` stays at `^1.2.0`.

## Commit 1 — emitter: include `integrationId` in messages sent to the Integration Engine

- `ieMessageBuilder`: optional `integrationId` on the outgoing message data interface.
- All 18 applicable call sites now include `data.integrationId`:
  - `orders.service.ts` (7): order results, create, cancel, tests.add, tests.cancel, manifest, get-from-provider (new optional param, passed from `reports.service.ts`).
  - `providers.service.ts` (7): services list/get, devices, refs version, breeds, sexes, species.
  - `integrations.service.ts` (4): integration create/update/remove (top-level, alongside the existing `payload.integrationId`) and test.
- Not included: the Heska results webhook (`results.controller.ts`) — it is an inbound request keyed by `clientId` with no integration in scope.

The engine currently ignores the field, so this is deployable independently.

## Commit 2 — receiver: persist `integrationId` and `practiceId` in external requests

- `ProviderRawDataDto`: optional `integrationId`.
- `ProviderExternalRequests` (Mongo): indexed `integrationId` and `practiceId`.
- `saveProviderRawData()`: when `integrationId` is present, resolves `practiceId` through `IntegrationsService.findOne` with `withDeleted: true` (requests from soft-deleted integrations still resolve). The lookup is cached in memory — the integration → practice pair is immutable and the integration count is bounded.
- Admin API: `integrationId` / `practiceId` filters (comma-separated lists, consistent with `providers`) on `GET /admin/external-requests` and `GET /admin/external-requests/stats`.

`raw_data` events without `integrationId` (current engine, Heska webhook) persist exactly as today.

## Tests

150/150 passing (3 new: practiceId resolution, lookup caching, unresolvable integration falls back to `integrationId`-only). Type-check and lint clean.

## Local e2e verification

With ActiveMQ up, publish a synthetic `raw_data` message including `integrationId` and check the `external_requests_v2` document gets `integrationId` + `practiceId`, then `GET /admin/external-requests?integrationId=...`. Full pipeline e2e (engine → provider) lands with PR 3a (idexx).
