### PR TITLE
Bump version to 1.13.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diagnostic-modality-integration-api",
-  "version": "1.13.18",
+  "version": "1.13.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diagnostic-modality-integration-api",
-      "version": "1.13.18",
+      "version": "1.13.19",
       "license": "UNLICENSED",
       "dependencies": {
         "@azure/core-auth": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-modality-integration-api",
-  "version": "1.13.18",
+  "version": "1.13.19",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
Bumps `package.json` from 1.13.18 → 1.13.19 to align main with the already-published release (tag `v1.13.19`, image in the dev ACR).

The tag and build went out via the `npm version` flow, but the push of the bump commit to main was rejected by the new branch protection rule (requires a PR). This PR closes that gap.

Ref: [dmi-api#302](https://github.com/nominal-systems/dmi-api/issues/302).