### PR TITLE
Port #307 wrong-patient fixes (orphan match window + integration-scoped lookups) to main

### DIFF
--- a/src/common/utils/provider-result-utils.spec.ts
+++ b/src/common/utils/provider-result-utils.spec.ts
@@ -16,6 +16,7 @@ describe('ProviderResultUtils', () => {
         {
           integrationId: 'integration A',
           status: OrderStatus.COMPLETED,
+          orphan: true,
           tests: [
             { code: 'fBNP' }
           ]
@@ -132,6 +133,85 @@ describe('ProviderResultUtils', () => {
       const existing = new Order()
       const extracted = new Order()
       expect(ProviderResultUtils.isMatchingOrder(existing, extracted)).toBe(false)
+    })
+  })
+
+  describe('match window (issue #307)', () => {
+    const mkOrphanOrder = (externalId: string, ageMinutes: number): Order => {
+      const o = new Order()
+      o.externalId = externalId
+      o.orphan = true // created from an orphan result
+      o.updatedAt = new Date(Date.now() - ageMinutes * 60_000)
+      return o
+    }
+
+    it('treats an order with orphan=true as an orphan order', () => {
+      const o = new Order(); o.externalId = '1'; o.orphan = true
+      expect(ProviderResultUtils.isOrphanOrder(o)).toBe(true)
+    })
+
+    it('does NOT treat a submitted/provider-fetched order (orphan unset) as an orphan', () => {
+      const o = new Order(); o.externalId = 'Jax' // orphan defaults to undefined/false
+      expect(ProviderResultUtils.isOrphanOrder(o)).toBe(false)
+    })
+
+    it('does NOT treat a provider-fetched order (no requisitionId, orphan=false) as an orphan', () => {
+      // Regression for #307 review #1: provider-fetched orders never set
+      // requisitionId, so the old requisitionId heuristic wrongly windowed them.
+      const o = new Order(); o.externalId = '117571776'; o.orphan = false
+      expect(ProviderResultUtils.isOrphanOrder(o)).toBe(false)
+    })
+
+    it('orphan match within the window is NOT stale', () => {
+      expect(ProviderResultUtils.isStaleOrphanMatch(mkOrphanOrder('1', 5))).toBe(false)
+    })
+
+    it('orphan match beyond the window IS stale', () => {
+      expect(ProviderResultUtils.isStaleOrphanMatch(mkOrphanOrder('1', 120))).toBe(true)
+    })
+
+    it('provider-fetched order (no requisitionId, orphan=false) is never stale even when old', () => {
+      // Regression for #307 review #1: a legitimate slow lab result must still
+      // reconcile to a provider-fetched order created hours/days earlier.
+      const o = new Order()
+      o.externalId = '117571776' // unique provider order id, no requisitionId
+      o.orphan = false
+      o.updatedAt = new Date(Date.now() - 24 * 60 * 60_000) // a day old
+      expect(ProviderResultUtils.isStaleOrphanMatch(o)).toBe(false)
+    })
+
+    it('submitted order (with requisitionId) is never stale even when old', () => {
+      const o = new Order()
+      o.externalId = 'Jax'
+      o.requisitionId = 'VOY-1772927557555'
+      o.updatedAt = new Date(Date.now() - 24 * 60 * 60_000)
+      expect(ProviderResultUtils.isStaleOrphanMatch(o)).toBe(false)
+    })
+
+    it('an orphan order without timestamps is never stale', () => {
+      const o = new Order(); o.externalId = '1'; o.orphan = true
+      expect(ProviderResultUtils.isStaleOrphanMatch(o)).toBe(false)
+    })
+
+    it('respects an explicit window and now at the boundary', () => {
+      const o = new Order(); o.externalId = '1'; o.orphan = true
+      o.updatedAt = new Date(1_000_000)
+      const windowMs = 60 * 60_000
+      expect(ProviderResultUtils.isStaleOrphanMatch(o, windowMs, 1_000_000 + windowMs)).toBe(false)
+      expect(ProviderResultUtils.isStaleOrphanMatch(o, windowMs, 1_000_000 + windowMs + 1)).toBe(true)
+    })
+
+    it('getMatchWindowMs defaults to 60 minutes and honours ORDER_MATCH_WINDOW_MINUTES', () => {
+      const prev = process.env.ORDER_MATCH_WINDOW_MINUTES
+      delete process.env.ORDER_MATCH_WINDOW_MINUTES
+      expect(ProviderResultUtils.getMatchWindowMs()).toBe(60 * 60_000)
+      process.env.ORDER_MATCH_WINDOW_MINUTES = '30'
+      expect(ProviderResultUtils.getMatchWindowMs()).toBe(30 * 60_000)
+      if (prev === undefined) {
+        delete process.env.ORDER_MATCH_WINDOW_MINUTES
+      } else {
+        process.env.ORDER_MATCH_WINDOW_MINUTES = prev
+      }
     })
   })
 })

--- a/src/common/utils/provider-result-utils.ts
+++ b/src/common/utils/provider-result-utils.ts
@@ -14,6 +14,10 @@ export class ProviderResultUtils {
   ): Order {
     const order = new Order()
     order.integrationId = integrationId
+    // Mark the order as orphan-created: it is matched only by a user-controlled,
+    // potentially non-unique externalId, so the externalId match window applies
+    // to it (issue #307). Submitted/provider-fetched orders are never marked.
+    order.orphan = true
     if (result.order?.externalId !== undefined) {
       order.externalId = result.order?.externalId
     }
@@ -107,5 +111,50 @@ export class ProviderResultUtils {
     system: string
   ): string | undefined {
     return identifiers?.find(id => id.system === system)?.value
+  }
+
+  // Default time window (minutes) within which a result sharing an orphan order's
+  // externalId is reconciled into it; beyond the window it is treated as a new
+  // episode. Overridable via ORDER_MATCH_WINDOW_MINUTES. See issue #307.
+  static readonly DEFAULT_MATCH_WINDOW_MINUTES = 60
+
+  static getMatchWindowMs (): number {
+    const minutes = Number(process.env.ORDER_MATCH_WINDOW_MINUTES ?? this.DEFAULT_MATCH_WINDOW_MINUTES)
+    const safe = Number.isFinite(minutes) && minutes > 0 ? minutes : this.DEFAULT_MATCH_WINDOW_MINUTES
+    return safe * 60_000
+  }
+
+  /**
+   * An order is an orphan when it was created from an orphan result (see
+   * extractOrderFromOrphanResult), i.e. matched only by a user-controlled,
+   * potentially non-unique externalId such as a placeholder number or the pet's
+   * name. Submitted and provider-fetched orders are NOT orphans (they carry a
+   * unique externalId/requisitionId) and are therefore never subject to the
+   * match window, so slow but legitimate lab results always reconcile to them.
+   *
+   * Note: this is keyed on the explicit `orphan` flag, not on requisitionId —
+   * provider-fetched orders also lack a requisitionId, so inferring orphan
+   * status from it would wrongly window them (issue #307 review).
+   */
+  static isOrphanOrder (order: Order): boolean {
+    return order.orphan === true
+  }
+
+  /**
+   * True when an orphan order's last activity is older than the match window,
+   * meaning an incoming result that merely shares its externalId is a different
+   * episode (e.g. externalId "1" or a reused pet name) and must not be
+   * reconciled into it. Non-orphan orders and orders without a timestamp are
+   * never considered stale.
+   */
+  static isStaleOrphanMatch (
+    order: Order,
+    windowMs: number = ProviderResultUtils.getMatchWindowMs(),
+    now: number = Date.now()
+  ): boolean {
+    if (!this.isOrphanOrder(order)) return false
+    const ts = order.updatedAt ?? order.createdAt
+    if (ts == null) return false
+    return now - new Date(ts).getTime() > windowMs
   }
 }

--- a/src/migrations/1782737809292-OrderOrphanFlag.ts
+++ b/src/migrations/1782737809292-OrderOrphanFlag.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class OrderOrphanFlag1782737809292 implements MigrationInterface {
+  name = 'OrderOrphanFlag1782737809292'
+
+  public async up (queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `order` ADD `orphan` tinyint NOT NULL DEFAULT 0')
+  }
+
+  public async down (queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `order` DROP COLUMN `orphan`')
+  }
+}

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -76,6 +76,13 @@ export class Order {
   @Column({ default: false })
   editable: boolean
 
+  // True when the order was created from an orphan result (matched only by a
+  // user-controlled, potentially non-unique externalId). Used to scope the
+  // externalId match window so it never applies to submitted/provider-fetched
+  // orders, which carry a unique externalId/requisitionId (issue #307).
+  @Column({ default: false })
+  orphan: boolean
+
   @Column('json', { nullable: true })
   labRequisitionInfo?: Record<string, any>
 

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -8,7 +8,13 @@ import { Repository } from 'typeorm'
 import { ReportsService } from '../reports/reports.service'
 import { IntegrationsService } from '../integrations/integrations.service'
 import { EventsService } from '../events/services/events.service'
-import { FileUtils, ProviderError, ProviderResult } from '@nominal-systems/dmi-engine-common'
+import {
+  FileUtils,
+  OrderStatus,
+  ProviderError,
+  ProviderResult,
+  ResultStatus,
+} from '@nominal-systems/dmi-engine-common'
 import * as fs from 'fs'
 import * as path from 'path'
 import { EventNamespace } from '../events/constants/event-namespace.enum'
@@ -981,6 +987,128 @@ describe('OrdersService', () => {
                   lastName: 'Staff',
                 },
               }),
+            }),
+          }),
+        )
+      })
+    })
+
+    // Regression for https://github.com/nominal-systems/dmi-api/issues/307
+    // User-typed externalIds ("1", "1234", "jax", ...) collide across OUs.
+    // findOneByExternalId matches by externalId globally, so a result for one
+    // patient could resolve to a different patient's order at another OU and
+    // emit a wrong-patient ORDER_UPDATED. The patient/client guard added in
+    // PR #286 must skip the update when the resolved order does not match the
+    // incoming result's integration/patient/client identity.
+    describe('cross-OU externalId collision (issue #307)', () => {
+      // Two orders at different OUs share the same user-typed externalId.
+      // The incoming result legitimately belongs to integration A's patient.
+      const SHARED_EXTERNAL_ID = '1'
+      const INTEGRATION_A = 'integration-a'
+      const INTEGRATION_B = 'integration-b'
+
+      const buildIncomingResultForA = (): ProviderResult =>
+        ({
+          id: 'result-a',
+          orderId: SHARED_EXTERNAL_ID,
+          status: ResultStatus.COMPLETED,
+          order: {
+            externalId: SHARED_EXTERNAL_ID,
+            status: OrderStatus.COMPLETED,
+            patient: {
+              name: 'Rex',
+              species: 'Canine',
+              sex: 'M',
+              breed: 'Beagle',
+              identifier: [],
+            },
+            client: { firstName: 'Alice', lastName: 'Anderson', identifier: [] },
+            veterinarian: { firstName: 'Dana', lastName: 'Vetson' },
+            tests: [],
+            editable: false,
+          },
+          testResults: [
+            {
+              seq: 1,
+              code: 'CBC',
+              name: 'Complete Blood Count',
+              items: [
+                { seq: 1, code: 'HCT', name: 'Hematocrit', status: 'DONE', valueString: '45' },
+              ],
+            },
+          ],
+        }) as unknown as ProviderResult
+
+      const buildExistingOrder = (
+        integrationId: string,
+        patientName: string,
+        clientLastName: string,
+      ): Order =>
+        ({
+          id: `order-${integrationId}`,
+          integrationId,
+          externalId: SHARED_EXTERNAL_ID,
+          status: OrderStatus.SUBMITTED,
+          patient: { name: patientName, identifier: [] },
+          client: { lastName: clientLastName, identifier: [] },
+        }) as unknown as Order
+
+      it('does not update a colliding order belonging to a different OU/patient', async () => {
+        // The global externalId lookup resolves to integration B's order, but
+        // the incoming result carries integration A's patient identity.
+        const orderB = buildExistingOrder(INTEGRATION_B, 'Whiskers', 'Brown')
+        const statusBefore = orderB.status
+        jest.spyOn(ordersService, 'findOneByExternalId').mockResolvedValueOnce(orderB)
+        const updateSpy = jest
+          .spyOn(ordersService, 'updateOrderFromResults')
+          .mockResolvedValue(false)
+
+        await ordersService.handleExternalOrderResults({
+          integrationId: INTEGRATION_A,
+          results: [buildIncomingResultForA()],
+        })
+
+        // B's order must be left untouched...
+        expect(updateSpy).not.toHaveBeenCalled()
+        expect(orderB.status).toBe(statusBefore)
+        // ...and no wrong-patient ORDER_UPDATED event may be emitted.
+        expect(eventsServiceMock.addEvent).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            namespace: EventNamespace.ORDERS,
+            type: EventType.ORDER_UPDATED,
+          }),
+        )
+      })
+
+      it('updates the matching order at the correct OU', async () => {
+        // The global externalId lookup resolves to integration A's own order,
+        // which matches the incoming result's patient/client identity.
+        const orderA = buildExistingOrder(INTEGRATION_A, 'Rex', 'Anderson')
+        jest.spyOn(ordersService, 'findOneByExternalId').mockResolvedValueOnce(orderA)
+        const updateSpy = jest
+          .spyOn(ordersService, 'updateOrderFromResults')
+          .mockResolvedValue(true)
+
+        await ordersService.handleExternalOrderResults({
+          integrationId: INTEGRATION_A,
+          results: [buildIncomingResultForA()],
+        })
+
+        // A's order is the one updated...
+        expect(updateSpy).toHaveBeenCalledTimes(1)
+        expect(updateSpy).toHaveBeenCalledWith(
+          orderA,
+          expect.objectContaining({ orderId: SHARED_EXTERNAL_ID }),
+        )
+        // ...and a correctly-scoped ORDER_UPDATED event is emitted for it.
+        expect(eventsServiceMock.addEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            namespace: EventNamespace.ORDERS,
+            type: EventType.ORDER_UPDATED,
+            integrationId: INTEGRATION_A,
+            data: expect.objectContaining({
+              orderId: orderA.id,
+              order: orderA,
             }),
           }),
         )

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1113,6 +1113,69 @@ describe('OrdersService', () => {
           }),
         )
       })
+
+      it('skips update for a stale same-OU orphan externalId reuse (pet-name-as-ID)', async () => {
+        // Same OU and the patient/client coincide (the ID is the pet name), but
+        // the existing orphan order was last touched outside the match window —
+        // i.e. a different episode reusing the same externalId.
+        const orderA = buildExistingOrder(INTEGRATION_A, 'Rex', 'Anderson')
+        orderA.orphan = true // created from an orphan result
+        orderA.updatedAt = new Date(Date.now() - 120 * 60_000)
+        jest.spyOn(ordersService, 'findOneByExternalId').mockResolvedValueOnce(orderA)
+        const updateSpy = jest
+          .spyOn(ordersService, 'updateOrderFromResults')
+          .mockResolvedValue(true)
+
+        await ordersService.handleExternalOrderResults({
+          integrationId: INTEGRATION_A,
+          results: [buildIncomingResultForA()],
+        })
+
+        expect(updateSpy).not.toHaveBeenCalled()
+        expect(eventsServiceMock.addEvent).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            namespace: EventNamespace.ORDERS,
+            type: EventType.ORDER_UPDATED,
+          }),
+        )
+      })
+
+      it('updates a recent same-OU orphan match within the window', async () => {
+        const orderA = buildExistingOrder(INTEGRATION_A, 'Rex', 'Anderson')
+        orderA.orphan = true // created from an orphan result
+        orderA.updatedAt = new Date() // within the match window
+        jest.spyOn(ordersService, 'findOneByExternalId').mockResolvedValueOnce(orderA)
+        const updateSpy = jest
+          .spyOn(ordersService, 'updateOrderFromResults')
+          .mockResolvedValue(true)
+
+        await ordersService.handleExternalOrderResults({
+          integrationId: INTEGRATION_A,
+          results: [buildIncomingResultForA()],
+        })
+
+        expect(updateSpy).toHaveBeenCalledTimes(1)
+      })
+
+      it('still updates a legitimate provider-fetched order (orphan=false) even when a day old', async () => {
+        // #307 review #1: provider-fetched orders never set requisitionId; they
+        // must NOT be treated as stale orphans, so slow lab results that arrive
+        // hours/days later still reconcile to them.
+        const orderA = buildExistingOrder(INTEGRATION_A, 'Rex', 'Anderson')
+        orderA.orphan = false // provider-fetched / submitted — not an orphan
+        orderA.updatedAt = new Date(Date.now() - 24 * 60 * 60_000)
+        jest.spyOn(ordersService, 'findOneByExternalId').mockResolvedValueOnce(orderA)
+        const updateSpy = jest
+          .spyOn(ordersService, 'updateOrderFromResults')
+          .mockResolvedValue(true)
+
+        await ordersService.handleExternalOrderResults({
+          integrationId: INTEGRATION_A,
+          results: [buildIncomingResultForA()],
+        })
+
+        expect(updateSpy).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -561,13 +561,19 @@ export class OrdersService {
       if (result == null) continue
 
       try {
-        const order = await this.findOneByExternalId(externalOrderId)
+        const order = await this.findOneByExternalId(externalOrderId, integrationId)
 
-        // Validate that the existing order matches the incoming result data
+        // Validate that the existing order matches the incoming result data, and
+        // that we are not reconciling into a stale orphan order whose externalId
+        // (e.g. a placeholder "1" or a pet name typed as the ID) was reused for a
+        // different episode beyond the match window (issue #307).
         if (result.order != null && order.patient?.name) {
           const extractedOrder = ProviderResultUtils.extractOrderFromOrphanResult(result, integrationId)
-          if (!ProviderResultUtils.isMatchingOrder(order, extractedOrder)) {
-            this.logger.warn(`Skipping order update for ${order.id}: patient/client mismatch (externalId=${externalOrderId})`)
+          const mismatch = !ProviderResultUtils.isMatchingOrder(order, extractedOrder)
+          const staleReuse = ProviderResultUtils.isStaleOrphanMatch(order)
+          if (mismatch || staleReuse) {
+            const reason = mismatch ? 'patient/client mismatch' : 'stale orphan externalId reuse'
+            this.logger.warn(`Skipping order update for ${order.id}: ${reason} (externalId=${externalOrderId})`)
             continue
           }
         }
@@ -655,10 +661,17 @@ export class OrdersService {
     return manifest
   }
 
-  async findOneByExternalId(externalId: string): Promise<Order> {
+  async findOneByExternalId(externalId: string, integrationId?: string): Promise<Order> {
+    // Scope the lookup by integration when known so a colliding externalId at a
+    // different OU can't be returned (issue #307). Callers without an
+    // integration context (e.g. admin tooling) keep the global lookup.
+    const scope = integrationId != null ? { integrationId } : {}
     return await this.findOne({
       options: {
-        where: [{ externalId: externalId }, { requisitionId: externalId }],
+        where: [
+          { externalId: externalId, ...scope },
+          { requisitionId: externalId, ...scope },
+        ],
         relations: [
           'patient',
           'patient.identifier',

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -2646,4 +2646,42 @@ describe('ReportsService', () => {
       })
     })
   })
+
+  describe('integration-scoped report lookups (issue #307)', () => {
+    const makeQbSpy = (): any => {
+      const qb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([])
+      }
+      ;(reportsRepositoryMock.createQueryBuilder as jest.Mock).mockReturnValue(qb)
+      return qb
+    }
+
+    it('scopes the report query by integrationId when provided', async () => {
+      const qb = makeQbSpy()
+      await reportsService.findReportsByExternalOrderIds(['1'], 'integration-A')
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'order.integrationId = :integrationId',
+        { integrationId: 'integration-A' }
+      )
+    })
+
+    it('does NOT scope by integration when integrationId is omitted (back-compat for admin lookups)', async () => {
+      const qb = makeQbSpy()
+      await reportsService.findReportsByExternalOrderIds(['1'])
+      expect(qb.andWhere).not.toHaveBeenCalled()
+    })
+
+    it('findReportByExternalOrderId forwards integrationId to the scoped lookup', async () => {
+      const spy = jest
+        .spyOn(reportsService, 'findReportsByExternalOrderIds')
+        .mockResolvedValueOnce([])
+      await reportsService.findReportByExternalOrderId('1', 'integration-A')
+      expect(spy).toHaveBeenCalledWith(['1'], 'integration-A')
+    })
+  })
 })

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -136,7 +136,7 @@ export class ReportsService {
     const createdOrders: Order[] = []
 
     // Update existing reports with new results
-    const existingReports = await this.findReportsByExternalOrderIds(externalOrderIds)
+    const existingReports = await this.findReportsByExternalOrderIds(externalOrderIds, integrationId)
     for (const report of existingReports) {
       const resultsForReport = results.filter(result => result.orderId === report.order.externalId)
       const updated = await this.updateReportResults(report, resultsForReport)
@@ -177,18 +177,25 @@ export class ReportsService {
       // Finding if order exists and saving order are done in parallel to improve performance.
       let order: Order | null
       try {
-        order = await this.ordersService.findOneByExternalId(extractedOrder.externalId)
+        order = await this.ordersService.findOneByExternalId(extractedOrder.externalId, integrationId)
       } catch (err) {
         order = null
       }
 
       this.logger.debug(`Orphan externalId=${extractedOrder.externalId}, existingOrder=${order?.id}, existingPatient=${order?.patient?.name}, extractedPatient=${extractedOrder.patient?.name}, existingClient=${order?.client?.lastName}, extractedClient=${extractedOrder.client?.lastName}`)
 
-      // Validate that the existing order matches the incoming result data
-      // TODO (LG): Remove log
-      if (order != null && !ProviderResultUtils.isMatchingOrder(order, extractedOrder)) {
-        this.logger.warn(`Orphan result externalId ${extractedOrder.externalId} matched order ${order.id} but patient/client data does not match. Creating new order.`)
-        order = null
+      // Reconcile into the existing order only when the patient/client identity
+      // matches AND the order's externalId wasn't reused for a different episode
+      // beyond the match window (issue #307). Otherwise create a new order so a
+      // reused placeholder/pet-name externalId doesn't blend distinct patients.
+      if (order != null) {
+        const mismatch = !ProviderResultUtils.isMatchingOrder(order, extractedOrder)
+        const staleReuse = ProviderResultUtils.isStaleOrphanMatch(order)
+        if (mismatch || staleReuse) {
+          const reason = mismatch ? 'patient/client mismatch' : 'stale orphan externalId reuse'
+          this.logger.warn(`Orphan result externalId ${extractedOrder.externalId} matched order ${order.id} but ${reason}. Creating new order.`)
+          order = null
+        }
       }
 
       if (order == null) {
@@ -196,7 +203,7 @@ export class ReportsService {
         dummyOrders.push(order)
       }
       const patient = order.patient !== null ? order.patient : extractedOrder.patient
-      let report = await this.findReportByExternalOrderId(order.externalId)
+      let report = await this.findReportByExternalOrderId(order.externalId, integrationId)
       if (report == null) {
         report = new Report()
         report.order = order
@@ -276,10 +283,11 @@ export class ReportsService {
   }
 
   async findReportsByExternalOrderIds (
-    externalOrderIds: string[]
+    externalOrderIds: string[],
+    integrationId?: string
   ): Promise<Report[]> {
     if (externalOrderIds.length === 0) return []
-    return await this.reportsRepository.createQueryBuilder('report')
+    const query = this.reportsRepository.createQueryBuilder('report')
       .leftJoinAndSelect('report.order', 'order')
       .leftJoinAndSelect('order.veterinarian', 'veterinarian')
       .leftJoinAndSelect('order.patient', 'patient')
@@ -292,15 +300,22 @@ export class ReportsService {
       .leftJoinAndSelect('reportPatient.identifier', 'reportPatientIdentifier')
       .leftJoinAndSelect('testResult.observations', 'observation')
       .where('order.externalId IN (:...externalOrderIds)', { externalOrderIds })
+    // Scope by integration when known so a colliding externalId at a different OU
+    // can't bind this OU's results onto another OU's report (issue #307).
+    if (integrationId != null) {
+      query.andWhere('order.integrationId = :integrationId', { integrationId })
+    }
+    return await query
       .orderBy('testResult.seq', 'ASC')
       .addOrderBy('observation.seq', 'ASC')
       .getMany()
   }
 
   async findReportByExternalOrderId (
-    externalOrderId: string
+    externalOrderId: string,
+    integrationId?: string
   ): Promise<Report | undefined> {
-    const reports = await this.findReportsByExternalOrderIds([externalOrderId])
+    const reports = await this.findReportsByExternalOrderIds([externalOrderId], integrationId)
     if (reports.length === 1) {
       return reports[0]
     }

--- a/src/reports/test/report.repository.mock.ts
+++ b/src/reports/test/report.repository.mock.ts
@@ -15,6 +15,7 @@ export const reportRepositoryMockFactory: () => Partial<Repository<Report>> = ()
   createQueryBuilder: jest.fn(() => ({
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
     addOrderBy: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockResolvedValue([])


### PR DESCRIPTION
## Summary

Ports the `#307` wrong-patient (blended IDEXX report) fixes from `hotfix/307-orphan-matching` onto `main`. These are the same changes currently deployed to DEV as `v1.13.18-hotfix.2`, re-based cleanly onto the diverged `main` line (NestJS 10, engine-common 1.4.0, integrationId-in-events).

Three atomic commits:

- **test(orders)**: regression for cross-OU externalId collision (`#307`)
- **fix(orders)**: integration-scoped `findOneByExternalId` + orphan-marked match window
- **fix(reports)**: integration-scoped report lookups to prevent cross-OU report blend

## What it does

- **Integration-scoped lookups**: `findOneByExternalId` / `findReportsByExternalOrderIds` / `findReportByExternalOrderId` take an optional `integrationId` so a colliding externalId at a different OU can no longer be returned or bound to another OU's report.
- **Orphan match window**: an explicit `orphan` flag on `Order` (set only when created from an orphan result) gates a configurable `ORDER_MATCH_WINDOW_MINUTES` (default 60) window. A reused placeholder/pet-name externalId (e.g. `"1"`, `"Jax"`) beyond the window is treated as a new episode instead of blending distinct patients. Submitted/provider-fetched orders carry a unique id and are **never** windowed, so slow lab results still reconcile.

## Why a cherry-pick port (not a branch merge)

`#286` is already on `main` (byte-identical to the hotfix's copy), and the hotfix carries `1.13.18-hotfix.x` version bumps that don't belong on `main`. A direct merge would drag both in. This PR is exactly the three substantive commits; `main`'s version stays `1.13.19`.

## Risk

- Cherry-pick applied with **zero conflicts** (`reports.service.ts` auto-merged). `provider-result-utils.ts`, `order.entity.ts`, the migration, and the report mock had no overlap with `main`.
- No new imports introduced; only stable TypeORM / entity / `Date` / `process.env` APIs used.
- **Schema migration** `OrderOrphanFlag` is additive (`ADD COLUMN orphan tinyint NOT NULL DEFAULT 0`), sorts last, and was verified applying cleanly in DEV. Existing orders default to `orphan = 0` (the window engages for new orphans only — intentionally conservative).

## Verification (against main's stack)

- `tsc --noEmit`: clean
- Full jest suite: **180/180 pass** (22 suites)
- ESLint (changed files): clean

Closes #307.
