### PR TITLE
Move event subscription delivery out of the request path

### DIFF
--- a/src/events/controllers/event-subscriptions.controller.ts
+++ b/src/events/controllers/event-subscriptions.controller.ts
@@ -3,6 +3,7 @@ import { ApiGuard } from '../../common/guards/api.guard'
 import { CreateEventSubscriptionDto } from '../dto/create-event-subscription.dto'
 import { EventSubscription } from '../entities/event-subscription.entity'
 import { EventSubscriptionService } from '../services/event-subscription.service'
+import { EventDeliveryService } from '../services/event-delivery.service'
 import { Organization } from '../../common/decorators/organization.decorator'
 import { Organization as OrganizationEntity } from '../../organizations/entities/organization.entity'
 
@@ -12,7 +13,8 @@ export class EventSubscriptionsController {
   private readonly logger = new Logger(EventSubscriptionsController.name)
 
   constructor (
-    private readonly eventSubscriptionService: EventSubscriptionService
+    private readonly eventSubscriptionService: EventSubscriptionService,
+    private readonly eventDeliveryService: EventDeliveryService
   ) {}
 
   @Get()
@@ -56,5 +58,6 @@ export class EventSubscriptionsController {
     @Param('id') subscriptionId: string
   ): Promise<void> {
     await this.eventSubscriptionService.delete(organization.id, subscriptionId)
+    this.eventDeliveryService.invalidateSubscription(subscriptionId)
   }
 }

--- a/src/events/entities/event-delivery.entity.ts
+++ b/src/events/entities/event-delivery.entity.ts
@@ -1,0 +1,48 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import * as mongoose from 'mongoose'
+
+export enum EventDeliveryStatus {
+  PENDING = 'PENDING',
+  PROCESSING = 'PROCESSING',
+  DELIVERED = 'DELIVERED',
+  FAILED = 'FAILED'
+}
+
+@Schema({ collection: 'event_deliveries', timestamps: true })
+export class EventDelivery {
+  @Prop({ index: true })
+  subscriptionId: string
+
+  @Prop({ type: mongoose.Schema.Types.Mixed })
+  event: any
+
+  @Prop({ index: true })
+  seq: number
+
+  @Prop({ enum: EventDeliveryStatus, default: EventDeliveryStatus.PENDING, index: true })
+  status: string
+
+  @Prop({ default: 0 })
+  attempts: number
+
+  @Prop({ index: true })
+  nextAttemptAt: Date
+
+  @Prop()
+  claimedAt: Date
+
+  @Prop()
+  lastError: string
+
+  @Prop()
+  deliveredAt: Date
+
+  @Prop({ type: Date, expires: '30d', default: () => new Date() })
+  expiresAt: Date
+}
+
+export type EventDeliveryDocument = EventDelivery & mongoose.Document
+
+export const EventDeliverySchema = SchemaFactory.createForClass(EventDelivery)
+
+EventDeliverySchema.index({ subscriptionId: 1, status: 1, seq: 1 })

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -2,6 +2,8 @@ import { forwardRef, Module } from '@nestjs/common'
 import { EventsService } from './services/events.service'
 import { EventsController } from './controllers/events.controller'
 import { Event, EventSchema } from './entities/event.entity'
+import { EventDelivery, EventDeliverySchema } from './entities/event-delivery.entity'
+import { EventDeliveryService } from './services/event-delivery.service'
 import { getConnectionToken, MongooseModule } from '@nestjs/mongoose'
 import { OrganizationsModule } from '../organizations/organizations.module'
 import { OrdersModule } from '../orders/orders.module'
@@ -28,6 +30,10 @@ import { IntegrationsModule } from '../integrations/integrations.module'
           return schema
         },
         inject: [getConnectionToken()]
+      },
+      {
+        name: EventDelivery.name,
+        useFactory: () => EventDeliverySchema
       }
     ]),
     TypeOrmModule.forFeature([EventSubscription]),
@@ -39,11 +45,13 @@ import { IntegrationsModule } from '../integrations/integrations.module'
   controllers: [EventsController, EventSubscriptionsController],
   providers: [
     EventsService,
-    EventSubscriptionService
+    EventSubscriptionService,
+    EventDeliveryService
   ],
   exports: [
     EventsService,
-    EventSubscriptionService
+    EventSubscriptionService,
+    EventDeliveryService
   ]
 })
 export class EventsModule {}

--- a/src/events/services/event-delivery.service.ts
+++ b/src/events/services/event-delivery.service.ts
@@ -1,0 +1,232 @@
+import { Inject, Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import { Model } from 'mongoose'
+import { EventHubProducerClient } from '@azure/event-hubs'
+import { AzureNamedKeyCredential } from '@azure/core-auth'
+import { EventSubscription } from '../entities/event-subscription.entity'
+import { EventDelivery, EventDeliveryDocument, EventDeliveryStatus } from '../entities/event-delivery.entity'
+import { EventDocument } from '../entities/event.entity'
+import { EventType } from '../constants/event-type.enum'
+import { EventSubscriptionService } from './event-subscription.service'
+import { IntegrationsService } from '../../integrations/integrations.service'
+
+const POLL_INTERVAL_MS = Number(process.env.EVENT_DELIVERY_POLL_MS ?? 2000)
+const MAX_ATTEMPTS = Number(process.env.EVENT_DELIVERY_MAX_ATTEMPTS ?? 10)
+const BATCH_PER_SUBSCRIPTION = 25
+const CLAIM_LEASE_MS = 2 * 60 * 1000
+const CIRCUIT_THRESHOLD = 5
+const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000
+const BASE_BACKOFF_MS = 30 * 1000
+const MAX_BACKOFF_MS = 60 * 60 * 1000
+
+interface CircuitState {
+  failures: number
+  openUntil: number
+}
+
+@Injectable()
+export class EventDeliveryService implements OnApplicationBootstrap, OnModuleDestroy {
+  private readonly logger = new Logger(EventDeliveryService.name)
+  private readonly producers = new Map<string, EventHubProducerClient>()
+  private readonly circuit = new Map<string, CircuitState>()
+  private timer: NodeJS.Timeout
+  private dispatching = false
+
+  constructor (
+    @InjectModel(EventDelivery.name)
+    private readonly deliveryModel: Model<EventDeliveryDocument>,
+    @Inject(EventSubscriptionService)
+    private readonly eventSubscriptionService: EventSubscriptionService,
+    @Inject(IntegrationsService)
+    private readonly integrationsService: IntegrationsService
+  ) {
+  }
+
+  onApplicationBootstrap (): void {
+    this.timer = setInterval(() => {
+      this.dispatch().catch(error => this.logger.error('Event delivery dispatch cycle failed', error))
+    }, POLL_INTERVAL_MS)
+  }
+
+  async onModuleDestroy (): Promise<void> {
+    clearInterval(this.timer)
+    for (const producer of this.producers.values()) {
+      await producer.close().catch(error => this.logger.debug(`Error closing producer: ${String(error?.message ?? error)}`))
+    }
+    this.producers.clear()
+  }
+
+  /**
+   * Persist one delivery record per subscription interested in this event.
+   * Called inline from the request path: local DB work only, no external I/O.
+   */
+  async enqueue (event: EventDocument): Promise<void> {
+    const integration = await this.integrationsService.findOne({
+      id: event.integrationId,
+      options: {
+        relations: ['practice']
+      }
+    })
+
+    if (integration == null) return
+
+    const subscriptions = await this.eventSubscriptionService.find({
+      where: {
+        event_type: event.type as EventType,
+        organizationId: integration.practice.organizationId
+      }
+    })
+
+    if (subscriptions.length === 0) return
+
+    await this.deliveryModel.insertMany(
+      subscriptions.map(subscription => ({
+        subscriptionId: subscription.id,
+        event: event.toObject(),
+        seq: event.seq,
+        status: EventDeliveryStatus.PENDING,
+        nextAttemptAt: new Date()
+      }))
+    )
+  }
+
+  invalidateSubscription (subscriptionId: string): void {
+    const producer = this.producers.get(subscriptionId)
+    if (producer !== undefined) {
+      this.producers.delete(subscriptionId)
+      producer.close().catch(error => this.logger.debug(`Error closing producer: ${String(error?.message ?? error)}`))
+    }
+    this.circuit.delete(subscriptionId)
+  }
+
+  private async dispatch (): Promise<void> {
+    if (this.dispatching) return
+    this.dispatching = true
+    try {
+      await this.reclaimExpiredLeases()
+      const subscriptionIds: string[] = await this.deliveryModel.distinct('subscriptionId', {
+        status: EventDeliveryStatus.PENDING,
+        nextAttemptAt: { $lte: new Date() }
+      })
+      await Promise.all(subscriptionIds.map(async subscriptionId => await this.dispatchSubscription(subscriptionId)))
+    } finally {
+      this.dispatching = false
+    }
+  }
+
+  /**
+   * Deliver pending events for one subscription, strictly in seq order.
+   * A failure stops the batch so later events never overtake a failed one.
+   */
+  private async dispatchSubscription (subscriptionId: string): Promise<void> {
+    const breaker = this.circuit.get(subscriptionId)
+    if (breaker !== undefined && breaker.openUntil > Date.now()) return
+
+    const [subscription] = await this.eventSubscriptionService.find({ where: { id: subscriptionId } })
+    if (subscription == null) {
+      await this.deliveryModel.updateMany(
+        { subscriptionId, status: EventDeliveryStatus.PENDING },
+        { $set: { status: EventDeliveryStatus.FAILED, lastError: 'Subscription no longer exists' } }
+      )
+      this.invalidateSubscription(subscriptionId)
+      return
+    }
+
+    for (let i = 0; i < BATCH_PER_SUBSCRIPTION; i++) {
+      const delivery = await this.deliveryModel.findOneAndUpdate(
+        {
+          subscriptionId,
+          status: EventDeliveryStatus.PENDING,
+          nextAttemptAt: { $lte: new Date() }
+        },
+        { $set: { status: EventDeliveryStatus.PROCESSING, claimedAt: new Date() } },
+        { sort: { seq: 1 }, new: true }
+      )
+      if (delivery == null) return
+
+      try {
+        await this.deliver(subscription, delivery)
+        await this.deliveryModel.updateOne(
+          { _id: delivery._id },
+          { $set: { status: EventDeliveryStatus.DELIVERED, deliveredAt: new Date() } }
+        )
+        this.circuit.delete(subscriptionId)
+      } catch (error) {
+        await this.recordFailure(delivery, error)
+        return
+      }
+    }
+  }
+
+  private async deliver (subscription: EventSubscription, delivery: EventDeliveryDocument): Promise<void> {
+    const producer = this.getProducer(subscription)
+    const eventData: Record<string, any> = delivery.event?.data ?? {}
+    const partitionKey: string | undefined = eventData.reportId ?? eventData.orderId ?? delivery.event?.accessionId
+    const eventDataBatch = await producer.createBatch({ ...(partitionKey != null && { partitionKey }) })
+    eventDataBatch.tryAdd({ body: delivery.event })
+    await producer.sendBatch(eventDataBatch)
+    this.logger.log(`Notifying subscription: ${subscription.id} of event '${delivery.event?.type}' (seq=${delivery.seq})`)
+  }
+
+  private getProducer (subscription: EventSubscription): EventHubProducerClient {
+    let producer = this.producers.get(subscription.id)
+    if (producer === undefined) {
+      const opts = subscription.subscription_options
+      const credential = new AzureNamedKeyCredential(opts.sa_key_name, opts.sa_key_value)
+      const namespace = [opts.hub_namespace, '.servicebus.windows.net'].join('')
+      producer = new EventHubProducerClient(namespace, opts.hub_name, credential, {
+        retryOptions: {
+          maxRetries: 1,
+          retryDelayInMs: 1000,
+          timeoutInMs: 5000
+        }
+      })
+      this.producers.set(subscription.id, producer)
+    }
+    return producer
+  }
+
+  private async recordFailure (delivery: EventDeliveryDocument, error: any): Promise<void> {
+    const attempts = delivery.attempts + 1
+    const exhausted = attempts >= MAX_ATTEMPTS
+    const backoffMs = Math.min(BASE_BACKOFF_MS * 2 ** delivery.attempts, MAX_BACKOFF_MS)
+    await this.deliveryModel.updateOne(
+      { _id: delivery._id },
+      {
+        $set: {
+          status: exhausted ? EventDeliveryStatus.FAILED : EventDeliveryStatus.PENDING,
+          attempts,
+          nextAttemptAt: new Date(Date.now() + backoffMs),
+          lastError: String(error?.message ?? error)
+        }
+      }
+    )
+
+    const breaker = this.circuit.get(delivery.subscriptionId) ?? { failures: 0, openUntil: 0 }
+    breaker.failures += 1
+    if (breaker.failures >= CIRCUIT_THRESHOLD) {
+      breaker.openUntil = Date.now() + CIRCUIT_COOLDOWN_MS
+      this.logger.warn(
+        `Circuit opened for subscription ${delivery.subscriptionId} after ${breaker.failures} consecutive failures`
+      )
+    }
+    this.circuit.set(delivery.subscriptionId, breaker)
+    this.logger.error(
+      `Error notifying subscription: ${delivery.subscriptionId} of event seq=${delivery.seq} (attempt ${attempts}${exhausted ? ', exhausted' : ''})`,
+      error
+    )
+  }
+
+  /**
+   * Deliveries claimed by a pod that died mid-send are returned to the queue.
+   */
+  private async reclaimExpiredLeases (): Promise<void> {
+    await this.deliveryModel.updateMany(
+      {
+        status: EventDeliveryStatus.PROCESSING,
+        claimedAt: { $lte: new Date(Date.now() - CLAIM_LEASE_MS) }
+      },
+      { $set: { status: EventDeliveryStatus.PENDING } }
+    )
+  }
+}

--- a/src/events/services/event-subscription.service.ts
+++ b/src/events/services/event-subscription.service.ts
@@ -1,14 +1,9 @@
-import { ConflictException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { EventSubscription } from '../entities/event-subscription.entity'
 import { FindManyOptions, Repository } from 'typeorm'
 import { CreateEventSubscriptionDto } from '../dto/create-event-subscription.dto'
-import { Event } from '../entities/event.entity'
-import { EventHubProducerClient } from '@azure/event-hubs'
-import { AzureNamedKeyCredential } from '@azure/core-auth'
 import { FindOneOfTypeOptions, toFindOneOptions } from '../../common/typings/find-one-of-type-options.interface'
-import { IntegrationsService } from '../../integrations/integrations.service'
-import { EventType } from '../constants/event-type.enum'
 
 @Injectable()
 export class EventSubscriptionService {
@@ -16,9 +11,7 @@ export class EventSubscriptionService {
 
   constructor (
     @InjectRepository(EventSubscription)
-    private readonly eventSubscriptionRepository: Repository<EventSubscription>,
-    @Inject(IntegrationsService)
-    private readonly integrationsService: IntegrationsService
+    private readonly eventSubscriptionRepository: Repository<EventSubscription>
   ) {
   }
 
@@ -75,42 +68,4 @@ export class EventSubscriptionService {
     await this.eventSubscriptionRepository.delete(eventSubscription.id)
   }
 
-  async notifySubscriptions (event: Event): Promise<void> {
-    // Find integration to get organizationId
-    const integration = await this.integrationsService.findOne({
-      id: event.integrationId,
-      options: {
-        relations: ['practice']
-      }
-    })
-
-    if (integration == null) return
-
-    // Find event subscriptions for organization/event type
-    const subscriptions = await this.eventSubscriptionRepository.find({
-      where: {
-        event_type: event.type as EventType,
-        organizationId: integration.practice.organizationId
-      }
-    })
-
-    // TODO(gb): optimize this by sending all subscriptions in one batch?
-    for (const subscription of subscriptions) {
-      try {
-        const opts = subscription.subscription_options
-        const credential = new AzureNamedKeyCredential(opts.sa_key_name, opts.sa_key_value)
-        const namespace = [opts.hub_namespace, '.servicebus.windows.net'].join('')
-        const producer = new EventHubProducerClient(namespace, opts.hub_name, credential)
-        const eventData: Record<string, any> = event.data ?? {}
-        const partitionKey: string | undefined = eventData.reportId ?? eventData.orderId ?? event.accessionId
-        const eventDataBatch = await producer.createBatch({ ...(partitionKey != null && { partitionKey }) })
-        eventDataBatch.tryAdd({ body: event })
-        await producer.sendBatch(eventDataBatch)
-        await producer.close()
-        this.logger.log(`Notifying subscription: ${subscription.id} of event '${event.type}'`)
-      } catch (error) {
-        this.logger.error(`Error notifying subscription: ${subscription.id} of event '${event.type}'`, error)
-      }
-    }
-  }
 }

--- a/src/events/services/events.service.ts
+++ b/src/events/services/events.service.ts
@@ -7,7 +7,7 @@ import { Event, EventDocument } from '../entities/event.entity'
 import { AddEventDto } from '../dto/add-event.dto'
 import { EventsQueryDto } from '../dto/events-query.dto'
 import { ModuleRef } from '@nestjs/core'
-import { EventSubscriptionService } from './event-subscription.service'
+import { EventDeliveryService } from './event-delivery.service'
 import { stringifyId } from '../../common/utils/shared.utils'
 import { PaginationDto } from '../../common/dtos/pagination.dto'
 
@@ -19,7 +19,7 @@ export class EventsService implements OnModuleInit {
   constructor (
     private readonly moduleRef: ModuleRef,
     @InjectModel(Event.name) private readonly eventModel: Model<EventDocument>,
-    @Inject(EventSubscriptionService) private readonly eventSubscriptionService: EventSubscriptionService
+    @Inject(EventDeliveryService) private readonly eventDeliveryService: EventDeliveryService
   ) {
   }
 
@@ -68,7 +68,11 @@ export class EventsService implements OnModuleInit {
   ): Promise<Event> {
     this.logger.debug(`Event: '${eventDto.type}'`)
     const event = await this.eventModel.create(eventDto)
-    await this.eventSubscriptionService.notifySubscriptions(event)
+    try {
+      await this.eventDeliveryService.enqueue(event)
+    } catch (error) {
+      this.logger.error(`Failed to enqueue event '${event.type}' for delivery`, error)
+    }
     return event
   }
 


### PR DESCRIPTION
### Problem

Event Hub notifications are sent inline during order requests (`ORDER_CREATED` and `ORDER_UPDATED`), creating a new producer client per event with default SDK retries. One slow or broken subscription endpoint (rotated SAS key, deleted hub) stalls `POST /orders` for minutes — a contributor to the production PIMS timeouts.

### Change

`addEvent` now writes a delivery record to a new `event_deliveries` Mongo collection, and a background dispatcher sends the notifications:

- Delivers per subscription in `seq` order (no reordering), polling every 2s
- Cached producer clients, 5s timeout / 1 retry
- Failed deliveries retry with backoff (up to 10 attempts) and record `lastError` — previously failures were silently dropped
- Circuit breaker isolates a broken subscription after 5 consecutive failures

### Delivery semantics

Notifications now arrive ~2s after the event instead of inline, and delivery is **at-least-once**: in rare failure windows (pod crash or send timeout between a successful send and its acknowledgment), a subscriber can receive the same event twice, byte-identical with the same `seq`. Consumers that upsert by order/report ID are unaffected; others should skip already-processed `seq` values. Previously delivery was at-most-once — failures silently dropped events.

### Notes

- No migration — the collection auto-creates, with a 30-day TTL
- Failed deliveries: `db.event_deliveries.find({status: 'FAILED'})` (worth alerting on)
- Build/lint clean, all tests pass. Staging check: point a test subscription at an unreachable Event Hub and confirm order submission latency is unaffected
