### PR TITLE
Store admin sessions in MongoDB to support multiple replicas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "argon2": "^0.28.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "connect-mongo": "^5.1.0",
         "faker": "^5.5.3",
         "fastify": "^4.28.1",
         "is-my-json-valid": "^2.20.5",
@@ -1412,6 +1413,7 @@
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -1656,6 +1658,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jas-/asn.1": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@jas-/asn.1/-/asn.1-5.4.2.tgz",
+      "integrity": "sha512-nq5BU3qkEMhj7U2h2biPPEIrK9bKCqkTd3HboUp81CkfzxYokEjrRCyzUJFOdQ3UGKWiwnSHdgKlU6jmcNhhEw==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": ">=5",
+        "inherits": ">=2",
+        "minimalistic-assert": ">=1",
+        "safer-buffer": ">=2"
       }
     },
     "node_modules/@jest/console": {
@@ -2130,7 +2144,6 @@
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.11",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -3006,6 +3019,7 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3015,6 +3029,7 @@
     },
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3027,6 +3042,7 @@
     },
     "node_modules/@npmcli/move-file/node_modules/brace-expansion": {
       "version": "1.1.15",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3036,6 +3052,7 @@
     },
     "node_modules/@npmcli/move-file/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3055,6 +3072,7 @@
     },
     "node_modules/@npmcli/move-file/node_modules/minimatch": {
       "version": "3.1.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3066,6 +3084,7 @@
     },
     "node_modules/@npmcli/move-file/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3077,6 +3096,7 @@
     },
     "node_modules/@npmcli/move-file/node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -3311,6 +3331,7 @@
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3650,6 +3671,16 @@
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -4074,6 +4105,7 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4085,6 +4117,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4686,6 +4719,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bn.js": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.4.tgz",
+      "integrity": "sha512-QL7sb18rJ1PbdsKsqPA0guxL563vIMwRHgzNrW/uzQuRGN1Cjqd/wonUBAVqHox9KwzHA6vCbM0lXx3k4iQMow==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "license": "MIT",
@@ -4927,6 +4966,7 @@
     },
     "node_modules/cacache": {
       "version": "15.3.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4955,6 +4995,7 @@
     },
     "node_modules/cacache/node_modules/brace-expansion": {
       "version": "1.1.15",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4964,6 +5005,7 @@
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4983,6 +5025,7 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4994,6 +5037,7 @@
     },
     "node_modules/cacache/node_modules/minimatch": {
       "version": "3.1.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -5005,6 +5049,7 @@
     },
     "node_modules/cacache/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -5016,6 +5061,7 @@
     },
     "node_modules/cacache/node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -5030,6 +5076,7 @@
     },
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -5217,6 +5264,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5460,6 +5508,23 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/connect-mongo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.1.0.tgz",
+      "integrity": "sha512-xT0vxQLqyqoUTxPLzlP9a/u+vir0zNkhiy9uAdHjSCcUUf7TS5b55Icw8lVyYFxfemP3Mf9gdwUOgeF3cxCAhw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "kruptein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "express-session": "^1.17.1",
+        "mongodb": ">= 5.1.0 < 7"
       }
     },
     "node_modules/consola": {
@@ -5980,6 +6045,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5988,6 +6054,7 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -6766,6 +6833,54 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cookie": "~0.7.2",
+        "cookie-signature": "~1.0.7",
+        "debug": "~2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "~5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.0.7",
@@ -7652,7 +7767,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -7826,6 +7941,7 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true
     },
@@ -7882,6 +7998,7 @@
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7959,7 +8076,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -7967,6 +8084,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7975,6 +8093,7 @@
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -8342,6 +8461,7 @@
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9488,6 +9608,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/kruptein": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.4.0.tgz",
+      "integrity": "sha512-zyzWq5d2RNglua4EIAxAyqPl2043wkpGRUmhTQ+Tjz8uDMnKnGwBqP32Co7vhp7nb7O1R5RI+lS4dzP0XDsdqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jas-/asn.1": ">=5",
+        "kruptein": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "license": "MIT",
@@ -9762,6 +9895,7 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -9788,6 +9922,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9799,6 +9934,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9812,6 +9948,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9824,6 +9961,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -9835,6 +9973,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -9873,8 +10012,7 @@
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
@@ -9972,6 +10110,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "dev": true,
@@ -10005,6 +10149,7 @@
     },
     "node_modules/minipass-collect": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10016,6 +10161,7 @@
     },
     "node_modules/minipass-fetch": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10032,6 +10178,7 @@
     },
     "node_modules/minipass-flush": {
       "version": "1.0.7",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
@@ -10043,6 +10190,7 @@
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10054,6 +10202,7 @@
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10109,6 +10258,74 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb/node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/mongoose": {
@@ -10511,6 +10728,7 @@
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10547,6 +10765,7 @@
     },
     "node_modules/node-gyp/node_modules/are-we-there-yet": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10559,6 +10778,7 @@
     },
     "node_modules/node-gyp/node_modules/brace-expansion": {
       "version": "1.1.15",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10568,6 +10788,7 @@
     },
     "node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10586,6 +10807,7 @@
     },
     "node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10605,6 +10827,7 @@
     },
     "node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10616,6 +10839,7 @@
     },
     "node_modules/node-gyp/node_modules/npmlog": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10630,6 +10854,7 @@
     },
     "node_modules/node-gyp/node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10835,6 +11060,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "license": "ISC",
@@ -10955,6 +11190,7 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11387,11 +11623,13 @@
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11497,6 +11735,16 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "license": "MIT"
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -11843,6 +12091,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12424,6 +12673,7 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12437,6 +12687,7 @@
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12481,7 +12732,6 @@
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -12549,6 +12799,7 @@
     },
     "node_modules/ssri": {
       "version": "8.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13246,6 +13497,19 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "dev": true,
@@ -13782,6 +14046,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "license": "MIT",
@@ -13815,6 +14092,7 @@
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -13823,6 +14101,7 @@
     },
     "node_modules/unique-slug": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14095,6 +14374,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "argon2": "^0.28.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "connect-mongo": "^5.1.0",
     "faker": "^5.5.3",
     "fastify": "^4.28.1",
     "is-my-json-valid": "^2.20.5",

--- a/src/common/plugins/fastify-plugins.ts
+++ b/src/common/plugins/fastify-plugins.ts
@@ -1,4 +1,4 @@
-import { INestApplication, Logger } from '@nestjs/common'
+import { INestApplication } from '@nestjs/common'
 import { FastifyInstance } from 'fastify'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
@@ -32,12 +32,11 @@ export async function registerFastifyPlugins (app: INestApplication): Promise<vo
       client: mongooseConnection.getClient() as unknown as MongoClient,
       collectionName: SESSIONS_COLLECTION,
       ttl: SESSION_MAX_AGE_MS / 1000,
-      // CosmosDB only honors TTL indexes on the system `_ts` field and rejects
-      // the `expires` TTL index connect-mongo would create — which would leave
-      // the store's collection promise rejected and crash the pod (unhandled
-      // rejection). Expired docs are cleaned up via the `_ts` index created
-      // below; stale sessions are rejected on read regardless (the store
-      // filters on `expires`, and @fastify/session checks the cookie expiry).
+      // CosmosDB only honors TTL on the system `_ts` field and rejects the
+      // `expires` TTL index connect-mongo would otherwise create at startup.
+      // Cleanup of expired docs is left to database provisioning (TTL on
+      // `_ts`); correctness never depends on it — the store filters on
+      // `expires` at read time and the session cookie expires regardless.
       autoRemove: 'disabled'
     }) as any,
     // Without this, every cookie-less request (all PIMS API traffic) would
@@ -50,25 +49,6 @@ export async function registerFastifyPlugins (app: INestApplication): Promise<vo
       maxAge: SESSION_MAX_AGE_MS
     }
   })
-
-  // Sliding session cleanup on CosmosDB: `_ts` is Cosmos' last-modified
-  // timestamp, updated on every session re-save, so docs expire 30 minutes
-  // after the last activity — matching the cookie maxAge. On plain MongoDB
-  // (local/dev) `_ts` does not exist, so this index is an inert no-op and
-  // sessions simply accumulate until they are rejected on read; do not
-  // "fix" this by indexing `expires`, Cosmos rejects TTL on that field.
-  // Best-effort: correctness never depends on this index, so a failure here
-  // must not take the pod down.
-  try {
-    await mongooseConnection.db
-      .collection(SESSIONS_COLLECTION)
-      .createIndex({ _ts: 1 }, { expireAfterSeconds: SESSION_MAX_AGE_MS / 1000 })
-  } catch (error) {
-    new Logger('SessionStore').warn(
-      `Could not create TTL index on '${SESSIONS_COLLECTION}': ${(error as Error).message}. ` +
-        'Expired session documents will not be cleaned up automatically.'
-    )
-  }
 
   await fastify.register(fastifyPassport.initialize())
 

--- a/src/common/plugins/fastify-plugins.ts
+++ b/src/common/plugins/fastify-plugins.ts
@@ -4,18 +4,34 @@ import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyPassport from '@fastify/passport'
 import { ConfigService } from '@nestjs/config'
+import { getConnectionToken } from '@nestjs/mongoose'
+import { Connection } from 'mongoose'
+import { MongoClient } from 'mongodb'
+import MongoStore from 'connect-mongo'
 import { AppConfig } from '../../config/config.interface'
+
+const SESSION_MAX_AGE_MS = 30 * 60 * 1000 // 30 minutes
 
 export async function registerFastifyPlugins (app: INestApplication): Promise<void> {
   const fastify = app.getHttpAdapter().getInstance() as FastifyInstance
   const configService = app.get<ConfigService<AppConfig>>(ConfigService)
+  const mongooseConnection = app.get<Connection>(getConnectionToken())
 
   await fastify.register(fastifyCookie)
   await fastify.register(fastifySession, {
     secret: configService.get<string>('secretKey') as string,
+    // Sessions must live outside pod memory so any replica can serve any
+    // request. Reuses the app's existing Mongo connection: mongoose 6 exposes a
+    // driver-v4 MongoClient while connect-mongo is typed against driver v5/v6,
+    // but the collection API surface the store uses is identical, hence the cast.
+    store: MongoStore.create({
+      clientPromise: Promise.resolve(mongooseConnection.getClient() as unknown as MongoClient),
+      collectionName: 'sessions',
+      ttl: SESSION_MAX_AGE_MS / 1000
+    }) as any,
     cookie: {
       secure: process.env.NODE_ENV === 'production',
-      maxAge: 30 * 60 * 1000 // 30 minutes
+      maxAge: SESSION_MAX_AGE_MS
     }
   })
 

--- a/src/common/plugins/fastify-plugins.ts
+++ b/src/common/plugins/fastify-plugins.ts
@@ -1,4 +1,4 @@
-import { INestApplication } from '@nestjs/common'
+import { INestApplication, Logger } from '@nestjs/common'
 import { FastifyInstance } from 'fastify'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
@@ -7,10 +7,14 @@ import { ConfigService } from '@nestjs/config'
 import { getConnectionToken } from '@nestjs/mongoose'
 import { Connection } from 'mongoose'
 import { MongoClient } from 'mongodb'
-import MongoStore from 'connect-mongo'
+// connect-mongo compiles to `module.exports = MongoStore` (export =); with
+// allowSyntheticDefaultImports and no esModuleInterop, a default import would
+// type-check but be undefined at runtime — import-require is the correct form.
+import MongoStore = require('connect-mongo')
 import { AppConfig } from '../../config/config.interface'
 
 const SESSION_MAX_AGE_MS = 30 * 60 * 1000 // 30 minutes
+const SESSIONS_COLLECTION = 'sessions'
 
 export async function registerFastifyPlugins (app: INestApplication): Promise<void> {
   const fastify = app.getHttpAdapter().getInstance() as FastifyInstance
@@ -25,15 +29,46 @@ export async function registerFastifyPlugins (app: INestApplication): Promise<vo
     // driver-v4 MongoClient while connect-mongo is typed against driver v5/v6,
     // but the collection API surface the store uses is identical, hence the cast.
     store: MongoStore.create({
-      clientPromise: Promise.resolve(mongooseConnection.getClient() as unknown as MongoClient),
-      collectionName: 'sessions',
-      ttl: SESSION_MAX_AGE_MS / 1000
+      client: mongooseConnection.getClient() as unknown as MongoClient,
+      collectionName: SESSIONS_COLLECTION,
+      ttl: SESSION_MAX_AGE_MS / 1000,
+      // CosmosDB only honors TTL indexes on the system `_ts` field and rejects
+      // the `expires` TTL index connect-mongo would create — which would leave
+      // the store's collection promise rejected and crash the pod (unhandled
+      // rejection). Expired docs are cleaned up via the `_ts` index created
+      // below; stale sessions are rejected on read regardless (the store
+      // filters on `expires`, and @fastify/session checks the cookie expiry).
+      autoRemove: 'disabled'
     }) as any,
+    // Without this, every cookie-less request (all PIMS API traffic) would
+    // persist a brand-new empty session to Mongo. Login flows modify the
+    // session, so they are still saved; rolling (default true) keeps re-saving
+    // active sessions, giving the sliding 30-minute expiry.
+    saveUninitialized: false,
     cookie: {
       secure: process.env.NODE_ENV === 'production',
       maxAge: SESSION_MAX_AGE_MS
     }
   })
+
+  // Sliding session cleanup on CosmosDB: `_ts` is Cosmos' last-modified
+  // timestamp, updated on every session re-save, so docs expire 30 minutes
+  // after the last activity — matching the cookie maxAge. On plain MongoDB
+  // (local/dev) `_ts` does not exist, so this index is an inert no-op and
+  // sessions simply accumulate until they are rejected on read; do not
+  // "fix" this by indexing `expires`, Cosmos rejects TTL on that field.
+  // Best-effort: correctness never depends on this index, so a failure here
+  // must not take the pod down.
+  try {
+    await mongooseConnection.db
+      .collection(SESSIONS_COLLECTION)
+      .createIndex({ _ts: 1 }, { expireAfterSeconds: SESSION_MAX_AGE_MS / 1000 })
+  } catch (error) {
+    new Logger('SessionStore').warn(
+      `Could not create TTL index on '${SESSIONS_COLLECTION}': ${(error as Error).message}. ` +
+        'Expired session documents will not be cleaned up automatically.'
+    )
+  }
 
   await fastify.register(fastifyPassport.initialize())
 


### PR DESCRIPTION
Closes #319

`@fastify/session` was using its default in-memory store, so admin (Okta/passport) sessions lived in the RAM of the pod that handled the login — with more than one dmi-api replica (#292), any request landing on a different pod is treated as anonymous. This PR moves sessions to MongoDB using `connect-mongo`, reusing the app's existing Mongo connection (no new infrastructure, no second connection pool): sessions survive pod restarts and rolling deploys, and load balancing stays fully even. The PIMS-facing API is unaffected (stateless `x-api-key`).

Implementation notes:
- `connect-mongo@^5` (v4 was ruled out: its `mongodb@^4` peer conflicts with TypeORM 0.3.30's `mongodb@^5.8||^6` optional peer and breaks plain `npm install`, which the Dockerfile relies on).
- Imported via `import MongoStore = require('connect-mongo')`: the package uses `export =` (`module.exports = MongoStore`), and with `allowSyntheticDefaultImports` but no `esModuleInterop` a default import type-checks yet compiles to an undefined `.default` access that throws at bootstrap.
- mongoose 6 exposes a driver-v4 `MongoClient` while connect-mongo v5 is typed against driver v5/v6 — the collection API surface the store uses is identical, hence the documented cast.
- Sessions are stored in the `sessions` collection with a TTL matching the 30-minute cookie `maxAge`.
- **Cleanup is Cosmos-aware** (see review below): `autoRemove: 'disabled'` stops connect-mongo from creating its `expires` TTL index — CosmosDB only honors TTL on the system `_ts` field and rejecting that index would leave the store's collection promise rejected, crash-looping the pod via unhandled rejection on Node 24. Cleanup of expired session documents is left to database provisioning (a `_ts` TTL of 1800s on the `sessions` collection — where exactly that lives is being discussed in the review); correctness never depends on it: the store filters on `expires` at read time and `@fastify/session` checks the cookie expiry. With `saveUninitialized: false` only admin sessions are ever persisted, so accumulation without the TTL is a handful of documents, and the TTL can be added to the collection at any point — no deploy-order coordination needed.
- **`saveUninitialized: false`**: with the default (`true`), every cookie-less request — i.e. all PIMS API traffic — would persist a brand-new empty session document (one Cosmos write per API request, constant churn). Login flows modify the session so they are still saved, and `rolling` keeps re-saving active sessions.

Verification:
- `npm run build`, `npm run lint`, `npm test`: clean, 22/22 suites, 180/180 tests passing.
- Smoke test booting the **compiled** `registerFastifyPlugins` (minimal Nest app: Config + Mongoose) against a real MongoDB 4, 13 checks passing: cookie-less request persists nothing and sets no cookie; login persists exactly one doc with a proper `Date` `expires` and sets the session cookie; session readable on a later request; rolling re-save advances `expires` (what makes a `_ts`-based sliding expiry work on Cosmos); the app creates no indexes on the collection; `destroy` removes the doc; a stale cookie reads as anonymous. This test is also what caught the broken default import — the previous smoke test exercised the store directly rather than the compiled wiring.

Left to the reviewer whether to include this in the current #292 rollout or right after; the interim alternative (Istio sticky sessions, no code change) is documented in #319.
