### PR TITLE
fix: shard external requests at practice level to end 30GB partition-cap storms

### DIFF
--- a/scripts/create-external-requests-v3.js
+++ b/scripts/create-external-requests-v3.js
@@ -1,0 +1,68 @@
+/*
+  Creates the sharded external_requests_v3 collection on Cosmos DB (Mongo API)
+  with its TTL index, ahead of deploying the code that writes to it. The app
+  also does this at startup (ProvidersService.onModuleInit), so running this
+  script is optional but lets ops verify the shard key before the deploy.
+
+  Idempotent — safe to run repeatedly.
+
+  Usage:
+    MONGO_URI='mongodb://...' node scripts/create-external-requests-v3.js
+*/
+
+const mongoose = require('mongoose')
+
+const COLLECTION = 'external_requests_v3'
+const SHARD_KEY = 'partitionKey'
+const TTL_SECONDS = Number(process.env.EXTERNAL_REQUESTS_TTL_SECONDS || 2592000)
+
+async function main() {
+  const MONGO_URI = process.env.MONGO_URI
+  if (!MONGO_URI) {
+    console.error('MONGO_URI is required')
+    process.exitCode = 1
+    return
+  }
+
+  const conn = await mongoose.createConnection(MONGO_URI, {
+    bufferCommands: false,
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  })
+
+  try {
+    try {
+      await conn.db.command({
+        customAction: 'CreateCollection',
+        collection: COLLECTION,
+        shardKey: SHARD_KEY,
+      })
+      console.log(`Created sharded collection ${COLLECTION} (shard key: ${SHARD_KEY})`)
+    } catch (err) {
+      const msg = (err && err.message) || String(err)
+      if (msg.includes('already exists')) {
+        console.log(`${COLLECTION} already exists — skipping creation`)
+      } else {
+        throw err
+      }
+    }
+
+    await conn.db.collection(COLLECTION).createIndex(
+      { _ts: 1 },
+      { expireAfterSeconds: TTL_SECONDS, name: 'ttl_ts_30d' }
+    )
+    console.log(`Ensured TTL index ttl_ts_30d (_ts, expireAfterSeconds=${TTL_SECONDS})`)
+
+    const stats = await conn.db.command({ customAction: 'GetCollection', collection: COLLECTION }).catch(() => undefined)
+    if (stats) {
+      console.log('Collection info:', JSON.stringify(stats))
+    }
+  } finally {
+    await conn.close()
+  }
+}
+
+main().catch((err) => {
+  console.error('Failed:', err.message || err)
+  process.exitCode = 1
+})

--- a/src/providers/entities/provider-external-requests-v3.entity.ts
+++ b/src/providers/entities/provider-external-requests-v3.entity.ts
@@ -1,0 +1,31 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import * as mongoose from 'mongoose'
+import { ProviderExternalRequests } from './provider-external-requests.entity'
+
+export const EXTERNAL_REQUESTS_V3_COLLECTION = 'external_requests_v3'
+export const EXTERNAL_REQUESTS_V3_SHARD_KEY = 'partitionKey'
+
+// Cosmos DB caps every logical partition at 30 GB. v2 was sharded on
+// `provider` (cardinality 3-4), so a single busy provider (idexx) fills its
+// partition and every write then fails with 403 / Substatus 1014. The v3
+// partition key scopes documents to provider + practice (falling back to
+// integration, then 'na') + UTC day, so no logical partition can outgrow one
+// day of one practice's traffic for one provider.
+export function buildExternalRequestPartitionKey (
+  provider: string,
+  scopeId: string | undefined,
+  createdAt: Date
+): string {
+  const day = createdAt.toISOString().slice(0, 10).replace(/-/g, '')
+  return `${provider}:${scopeId ?? 'na'}:${day}`
+}
+
+@Schema({ collection: EXTERNAL_REQUESTS_V3_COLLECTION })
+export class ProviderExternalRequestsV3 extends ProviderExternalRequests {
+  @Prop({ required: true, index: true })
+  partitionKey: string
+}
+
+export type ProviderExternalRequestV3Document = ProviderExternalRequestsV3 & mongoose.Document
+
+export const ProviderExternalRequestsV3Schema = SchemaFactory.createForClass(ProviderExternalRequestsV3)

--- a/src/providers/providers.module.ts
+++ b/src/providers/providers.module.ts
@@ -12,6 +12,7 @@ import activeMQClientProvider from '../common/providers/activemq-client.provider
 import { Integration } from '../integrations/entities/integration.entity'
 import { getConnectionToken, MongooseModule } from '@nestjs/mongoose'
 import { ProviderExternalRequests, ProviderExternalRequestsSchema } from './entities/provider-external-requests.entity'
+import { ProviderExternalRequestsV3, ProviderExternalRequestsV3Schema } from './entities/provider-external-requests-v3.entity'
 import { Provider } from './entities/provider.entity'
 import { ProviderOption } from './entities/provider-option.entity'
 
@@ -23,6 +24,13 @@ import { ProviderOption } from './entities/provider-option.entity'
         name: ProviderExternalRequests.name,
         useFactory: () => {
           return ProviderExternalRequestsSchema
+        },
+        inject: [getConnectionToken()]
+      },
+      {
+        name: ProviderExternalRequestsV3.name,
+        useFactory: () => {
+          return ProviderExternalRequestsV3Schema
         },
         inject: [getConnectionToken()]
       }

--- a/src/providers/services/providers.service.spec.ts
+++ b/src/providers/services/providers.service.spec.ts
@@ -5,6 +5,7 @@ import { Model } from 'mongoose'
 import * as fs from 'fs'
 import * as path from 'path'
 import { ProviderExternalRequestDocument } from '../entities/provider-external-requests.entity'
+import { buildExternalRequestPartitionKey, ProviderExternalRequestV3Document } from '../entities/provider-external-requests-v3.entity'
 import { Test, TestingModule } from '@nestjs/testing'
 import { getModelToken } from '@nestjs/mongoose'
 import { ConfigService } from '@nestjs/config'
@@ -38,6 +39,7 @@ describe('ProvidersService', () => {
   let integrationsService: IntegrationsService
   // let clientProxy: ClientProxy
   let providerExternalRequestsModel: Model<ProviderExternalRequestDocument>
+  let providerExternalRequestsV3Model: Model<ProviderExternalRequestV3Document>
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -57,7 +59,8 @@ describe('ProvidersService', () => {
           useValue: providerConfigurationRepositoryMock
         },
         { provide: ClientProxy, useValue: {} },
-        { provide: getModelToken('ProviderExternalRequests'), useValue: { create: jest.fn() } },
+        { provide: getModelToken('ProviderExternalRequests'), useValue: { create: jest.fn(), countDocuments: jest.fn() } },
+        { provide: getModelToken('ProviderExternalRequestsV3'), useValue: { create: jest.fn(), countDocuments: jest.fn() } },
         {
           provide: getRepositoryToken(Provider),
           useValue: providersRepositoryMock
@@ -77,6 +80,7 @@ describe('ProvidersService', () => {
     integrationsService = module.get<IntegrationsService>(IntegrationsService)
     // clientProxy = module.get<ClientProxy>(ClientProxy)
     providerExternalRequestsModel = module.get<Model<any>>(getModelToken('ProviderExternalRequests'))
+    providerExternalRequestsV3Model = module.get<Model<any>>(getModelToken('ProviderExternalRequestsV3'))
   })
 
   afterEach(() => {
@@ -85,7 +89,7 @@ describe('ProvidersService', () => {
 
   describe('saveProviderRawData', () => {
     it('should save the correct raw data having a JSON body', async () => {
-      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
       const data = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'externalRequests', 'results.json'), 'utf8'))
 
       await service.saveProviderRawData(data)
@@ -97,13 +101,14 @@ describe('ProvidersService', () => {
         url: data.url,
         method: data.method,
         provider: data.provider,
-        status: data.status
+        status: data.status,
+        partitionKey: expect.stringMatching(new RegExp(`^${String(data.provider)}:na:\\d{8}$`))
       }, expect.any(Function))
 
       createSpy.mockRestore()
     })
     it('should save the correct raw data having a XML body', async () => {
-      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
       const data = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'externalRequests', 'results.json'), 'utf8'))
       data.body = fs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'externalRequests', 'results.xml'), 'utf8')
       await service.saveProviderRawData(data)
@@ -115,13 +120,14 @@ describe('ProvidersService', () => {
         url: data.url,
         method: data.method,
         provider: data.provider,
-        status: data.status
+        status: data.status,
+        partitionKey: expect.stringMatching(new RegExp(`^${String(data.provider)}:na:\\d{8}$`))
       }, expect.any(Function))
 
       createSpy.mockRestore()
     })
     it('should save the payload when defined', async () => {
-      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
       const data = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'externalRequests', 'result-payload.json'), 'utf8'))
 
       await service.saveProviderRawData(data)
@@ -134,13 +140,14 @@ describe('ProvidersService', () => {
         method: data.method,
         provider: data.provider,
         status: data.status,
-        payload: data.payload
+        payload: data.payload,
+        partitionKey: expect.stringMatching(new RegExp(`^${String(data.provider)}:na:\\d{8}$`))
       }, expect.any(Function))
 
       createSpy.mockRestore()
     })
     it('should remove duplicate accession IDs before saving', async () => {
-      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
 
       const data = {
         headers: { 'Content-Type': 'application/json' },
@@ -165,7 +172,7 @@ describe('ProvidersService', () => {
       createSpy.mockRestore()
     })
     it('should resolve and save the practiceId when integrationId is present', async () => {
-      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
       const findOneSpy = jest.spyOn(integrationsService, 'findOne').mockResolvedValue({
         id: 'integration-1',
         practiceId: 'practice-1'
@@ -191,7 +198,8 @@ describe('ProvidersService', () => {
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           integrationId: 'integration-1',
-          practiceId: 'practice-1'
+          practiceId: 'practice-1',
+          partitionKey: expect.stringMatching(/^test-provider:practice-1:\d{8}$/)
         }),
         expect.any(Function)
       )
@@ -224,7 +232,7 @@ describe('ProvidersService', () => {
       findOneSpy.mockRestore()
     })
     it('should save the integrationId without practiceId when the integration cannot be resolved', async () => {
-      const createSpy = jest.spyOn(providerExternalRequestsModel, 'create')
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
       const findOneSpy = jest.spyOn(integrationsService, 'findOne')
         .mockRejectedValue(new Error('The integration was not found'))
 
@@ -243,7 +251,8 @@ describe('ProvidersService', () => {
 
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          integrationId: 'missing-integration'
+          integrationId: 'missing-integration',
+          partitionKey: expect.stringMatching(/^test-provider:missing-integration:\d{8}$/)
         }),
         expect.any(Function)
       )
@@ -252,6 +261,26 @@ describe('ProvidersService', () => {
 
       createSpy.mockRestore()
       findOneSpy.mockRestore()
+    })
+  })
+  describe('buildExternalRequestPartitionKey', () => {
+    it('should scope the key to provider, practice and UTC day', () => {
+      const createdAt = new Date('2026-07-05T23:59:59.999Z')
+      expect(buildExternalRequestPartitionKey('idexx', 'practice-42', createdAt))
+        .toEqual('idexx:practice-42:20260705')
+    })
+    it('should fall back to na when no practice or integration is available', () => {
+      const createdAt = new Date('2026-01-02T00:00:00.000Z')
+      expect(buildExternalRequestPartitionKey('zoetis', undefined, createdAt))
+        .toEqual('zoetis:na:20260102')
+    })
+  })
+  describe('countExternalRequests', () => {
+    it('should sum counts from v3 and the draining v2 collection', async () => {
+      jest.spyOn(providerExternalRequestsV3Model, 'countDocuments').mockResolvedValue(7 as never)
+      jest.spyOn(providerExternalRequestsModel, 'countDocuments').mockResolvedValue(5 as never)
+
+      expect(await service.countExternalRequests({ provider: 'idexx' })).toEqual(12)
     })
   })
   describe('checkLabRequisitionParameters()', () => {

--- a/src/providers/services/providers.service.ts
+++ b/src/providers/services/providers.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common'
 import { ClientProxy } from '@nestjs/microservices'
 import { IntegrationsService } from '../../integrations/integrations.service'
 import ieMessageBuilder from '../../common/utils/ieMessageBuilder'
@@ -17,6 +17,13 @@ import {
   ProviderExternalRequestDocument,
   ProviderExternalRequests
 } from '../entities/provider-external-requests.entity'
+import {
+  buildExternalRequestPartitionKey,
+  EXTERNAL_REQUESTS_V3_COLLECTION,
+  EXTERNAL_REQUESTS_V3_SHARD_KEY,
+  ProviderExternalRequestsV3,
+  ProviderExternalRequestV3Document
+} from '../entities/provider-external-requests-v3.entity'
 import { FilterQuery, Model } from 'mongoose'
 import { InjectModel } from '@nestjs/mongoose'
 import { ProviderRawDataDto } from '../dtos/provider-raw-data.dto'
@@ -30,8 +37,12 @@ import { nestKeys } from '../../common/utils/nest-keys'
 import { PaginationDto } from '../../common/dtos/pagination.dto'
 import { isNullOrEmpty, stringifyId } from '../../common/utils/shared.utils'
 
+// Matches the TTL on external_requests_v2 (ttl_ts_30d). Cosmos evaluates it
+// against the internal `_ts` (last-modified) timestamp.
+const EXTERNAL_REQUESTS_TTL_SECONDS = Number(process.env.EXTERNAL_REQUESTS_TTL_SECONDS ?? 2592000)
+
 @Injectable()
-export class ProvidersService {
+export class ProvidersService implements OnModuleInit {
   private readonly logger = new Logger(ProvidersService.name)
   private readonly practiceIdCache = new Map<string, string>()
 
@@ -40,9 +51,46 @@ export class ProvidersService {
     private readonly providerRepository: Repository<Provider>,
     private readonly integrationsService: IntegrationsService,
     @InjectModel(ProviderExternalRequests.name) private readonly providerExternalRequestsModel: Model<ProviderExternalRequestDocument>,
+    @InjectModel(ProviderExternalRequestsV3.name) private readonly providerExternalRequestsV3Model: Model<ProviderExternalRequestV3Document>,
     @Inject('ACTIVEMQ') private readonly client: ClientProxy,
     @InjectRepository(ProviderOption) private readonly providerOptionRepository: Repository<ProviderOption>
   ) {
+  }
+
+  async onModuleInit (): Promise<void> {
+    await this.ensureExternalRequestsV3Collection()
+  }
+
+  // Cosmos creates unsharded collections implicitly on first write; an
+  // unsharded external_requests_v3 would put every document in a single
+  // 30 GB-capped partition, silently reintroducing the 1014 storms. Creating
+  // it here with an explicit shard key makes that impossible. Idempotent, and
+  // a no-op (with a warning) on non-Cosmos MongoDB.
+  private async ensureExternalRequestsV3Collection (): Promise<void> {
+    const db = this.providerExternalRequestsV3Model.db.db
+    try {
+      await db.command({
+        customAction: 'CreateCollection',
+        collection: EXTERNAL_REQUESTS_V3_COLLECTION,
+        shardKey: EXTERNAL_REQUESTS_V3_SHARD_KEY
+      })
+      this.logger.log(`Created sharded collection ${EXTERNAL_REQUESTS_V3_COLLECTION} (shard key: ${EXTERNAL_REQUESTS_V3_SHARD_KEY})`)
+    } catch (error) {
+      const message: string = error?.message ?? String(error)
+      if (message.includes('already exists')) {
+        // expected on every boot after the first
+      } else {
+        this.logger.warn(`Could not ensure sharded collection ${EXTERNAL_REQUESTS_V3_COLLECTION} (non-Cosmos MongoDB?): ${message}`)
+      }
+    }
+    try {
+      await db.collection(EXTERNAL_REQUESTS_V3_COLLECTION).createIndex(
+        { _ts: 1 },
+        { expireAfterSeconds: EXTERNAL_REQUESTS_TTL_SECONDS, name: 'ttl_ts_30d' }
+      )
+    } catch (error) {
+      this.logger.warn(`Could not ensure TTL index on ${EXTERNAL_REQUESTS_V3_COLLECTION}: ${error?.message ?? String(error)}`)
+    }
   }
 
   async findAll (
@@ -355,15 +403,17 @@ export class ProvidersService {
       accessionIds = [...new Set(data.accessionIds)]
     }
 
-    const rawData: ProviderExternalRequests = {
-      createdAt: new Date(),
+    const createdAt = new Date()
+    const rawData: ProviderExternalRequestsV3 = {
+      createdAt,
       provider,
       accessionIds,
       status,
       method,
       url,
       headers: nestKeys(headers),
-      body: nestKeys(body) // Nest keys to ensure MongoDB safety
+      body: nestKeys(body), // Nest keys to ensure MongoDB safety
+      partitionKey: buildExternalRequestPartitionKey(provider, undefined, createdAt)
     }
 
     if (integrationId !== undefined) {
@@ -372,20 +422,21 @@ export class ProvidersService {
       if (practiceId !== undefined) {
         rawData.practiceId = practiceId
       }
+      rawData.partitionKey = buildExternalRequestPartitionKey(provider, practiceId ?? integrationId, createdAt)
     }
 
     if (payload !== undefined) {
       rawData.payload = payload
     }
 
-    this.providerExternalRequestsModel.create(rawData, (error) => {
+    this.providerExternalRequestsV3Model.create(rawData, (error) => {
       if (error != null && error.name === 'MongoError') {
         this.logger.error(error.message)
         this.logger.warn(`Could not save external request (${method} ${url}) to the database, saving without the body`)
 
         // TODO(gb): implement a better fallback strategy than just removing the body
         delete rawData.body
-        this.providerExternalRequestsModel.create(rawData, (error) => {
+        this.providerExternalRequestsV3Model.create(rawData, (error) => {
           if (error != null && error.name === 'MongoError') {
             this.logger.error(error.message)
             this.logger.warn('Could not save external request (without the body) to database')
@@ -416,11 +467,17 @@ export class ProvidersService {
     }
   }
 
+  // external_requests_v2 is being drained by its 30-day TTL after the move to
+  // the practice-level-sharded external_requests_v3; reads merge both
+  // collections until v2 is empty and the v2 model can be removed.
   async findAllExternalRequests (
     query: FilterQuery<ProviderExternalRequestDocument>
   ): Promise<ProviderExternalRequests[]> {
-    const docs = await this.providerExternalRequestsModel.find(query, { __v: 0 }, { lean: true })
-    return docs.map(stringifyId)
+    const [v3Docs, v2Docs] = await Promise.all([
+      this.providerExternalRequestsV3Model.find(query, { __v: 0 }, { lean: true }),
+      this.providerExternalRequestsModel.find(query, { __v: 0 }, { lean: true })
+    ])
+    return [...v3Docs, ...v2Docs].map(stringifyId)
   }
 
   async findExternalRequests (
@@ -428,19 +485,31 @@ export class ProvidersService {
     paginationDto: PaginationDto
   ): Promise<ProviderExternalRequests[]> {
     const { page, limit } = paginationDto
-    const docs = await this.providerExternalRequestsModel.find(query, { __v: 0, body: 0, payload: 0 }, {
-      limit,
-      skip: (page - 1) * limit,
-      sort: { createdAt: -1 },
-      lean: true
-    })
-    return docs.map(stringifyId)
+    // Each collection is over-fetched up to the requested page's end, then the
+    // merged result is re-sorted and sliced, so pagination stays globally
+    // correct while both collections hold data.
+    const fetchUpToPageEnd = async (model: Model<any>): Promise<any[]> =>
+      await model.find(query, { __v: 0, body: 0, payload: 0 }, {
+        limit: page * limit,
+        sort: { createdAt: -1 },
+        lean: true
+      })
+    const [v3Docs, v2Docs] = await Promise.all([
+      fetchUpToPageEnd(this.providerExternalRequestsV3Model),
+      fetchUpToPageEnd(this.providerExternalRequestsModel)
+    ])
+    const merged = [...v3Docs, ...v2Docs].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+    const skip = (page - 1) * limit
+    return merged.slice(skip, skip + limit).map(stringifyId)
   }
 
   async findExternalRequestById (
     id: string
   ): Promise<ProviderExternalRequestDocument> {
-    const doc = await this.providerExternalRequestsModel.findById(id, { __v: 0 }, { lean: true }).exec()
+    const doc = await this.providerExternalRequestsV3Model.findById(id, { __v: 0 }, { lean: true }).exec() ??
+      await this.providerExternalRequestsModel.findById(id, { __v: 0 }, { lean: true }).exec()
     if (doc === null) {
       throw new NotFoundException(`The external request ${id} doesn't exist`)
     } else {
@@ -451,7 +520,11 @@ export class ProvidersService {
   async countExternalRequests (
     options: FilterQuery<ProviderExternalRequestDocument>
   ): Promise<number> {
-    return await this.providerExternalRequestsModel.countDocuments(options)
+    const [v3Count, v2Count] = await Promise.all([
+      this.providerExternalRequestsV3Model.countDocuments(options),
+      this.providerExternalRequestsModel.countDocuments(options)
+    ])
+    return v3Count + v2Count
   }
 
   async update (
@@ -463,7 +536,7 @@ export class ProvidersService {
   async externalRequestsStats (
     query: FilterQuery<ProviderExternalRequestDocument>
   ): Promise<any> {
-    return await this.providerExternalRequestsModel.aggregate([
+    const pipeline = [
       {
         $match: query
       },
@@ -490,6 +563,21 @@ export class ProvidersService {
           count: 1
         }
       }
+    ]
+    const [v3Stats, v2Stats] = await Promise.all([
+      this.providerExternalRequestsV3Model.aggregate(pipeline),
+      this.providerExternalRequestsModel.aggregate(pipeline)
     ])
+    const byBucket = new Map<string, any>()
+    for (const row of [...v3Stats, ...v2Stats]) {
+      const key = `${String(row.provider)}:${String(row.year)}-${String(row.month)}-${String(row.day)}T${String(row.hour)}`
+      const existing = byBucket.get(key)
+      if (existing === undefined) {
+        byBucket.set(key, { ...row })
+      } else {
+        existing.count += row.count
+      }
+    }
+    return Array.from(byBucket.values())
   }
 }


### PR DESCRIPTION
## Problem

`external_requests_v2` is sharded on `provider`, whose live cardinality is **3** (`idexx`, `wisdom-panel`, `zoetis` — `antech` has zero documents). All idexx traffic lands in one Cosmos logical partition, which repeatedly hits the **30 GB hard cap**; every subsequent write fails with `Forbidden (403); Substatus 1014` and the audit trail (including PDF bodies) is silently dropped. This is the root cause of the recurring `partition-1014-storm` incidents (dmi-monitor incident #10, re-opened today, 2026-07-05). The 30-day TTL cannot keep up because each delete costs ~60 RU (26 KB average docs + `$**` wildcard-index maintenance).

## Fix

Writes move to a new collection **`external_requests_v3`**, sharded on a synthetic **`partitionKey`**:

```
{provider}:{practiceId ?? integrationId ?? 'na'}:{yyyymmdd}
```

- **Practice-level** as planned, with the UTC-day suffix bounding the worst case: even documents with no integration context (`provider:na:day`) can never accumulate more than one day of one provider's traffic in a single logical partition (~2.3 GB at today's peak volume — 13× headroom under the cap).
- **Cannot be silently unsharded**: `ProvidersService.onModuleInit` creates the collection via the Cosmos `customAction: CreateCollection` with an explicit shard key (idempotent; logs a warning and no-ops on vanilla MongoDB in dev). Without this, the first mongoose write would implicitly create an *unsharded* collection and reintroduce the cap. `scripts/create-external-requests-v3.js` does the same standalone so ops can pre-create and verify before the deploy.
- **Same TTL**: a `ttl_ts_30d` index (`_ts`, `expireAfterSeconds` 2592000, overridable via `EXTERNAL_REQUESTS_TTL_SECONDS`) is ensured on v3.
- **No `$**` wildcard index on v3** — only the per-field indexes the entity declares. On v2 the wildcard index made every write/delete pay ~60 RU; v3 writes should be several times cheaper.

## Transition (no backfill needed)

Reads (`findAllExternalRequests`, `findExternalRequests`, `countExternalRequests`, `findExternalRequestById`, `externalRequestsStats`) merge **v3 + v2** while the v2 TTL drains it. In ≤30 days v2 is empty; a follow-up PR removes the v2 model and drops the collection. Paginated reads over-fetch to page-end from each collection and re-sort, so ordering stays globally correct during the window. If a backfill is ever wanted instead, `scripts/mongo-shard-migrate.js` can copy v2 → v3 (it would need a small transform to compute `partitionKey`), but TTL + dual-read makes that unnecessary.

## Test plan

- [x] `npx nest build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 22/22 suites, **183/183** tests (3 new: partition-key derivation ×2, dual-collection count)
- [ ] Staging: boot the app, verify the startup log `Created sharded collection external_requests_v3 (shard key: partitionKey)` and `sh.status()`/`GetCollection` shows the shard key
- [ ] Staging: place an order, verify the raw-data doc lands in v3 with a well-formed `partitionKey` and that the admin External Requests screen shows both old (v2) and new (v3) entries
- [ ] Prod deploy: optionally pre-run `scripts/create-external-requests-v3.js`, then deploy; watch `Substatus 1014` in Log Analytics (should stay zero) and per-partition sizes in Azure Monitor

## Context

- Today's mitigation (manual purge of old idexx docs from v2) bought headroom but does not remove the cap — this PR does.
- Note for anyone touching v2 by hand: `_ts` is **not queryable** via the Mongo API (predicates on it match nothing) and `createdAt` is a real BSON `Date`, not a string.

## Related work

Cross-referenced against all open/draft/recently-closed PRs, branches, and issues in the `nominal-systems` org (2026-07-05). **No competing or conflicting shard-key work exists** — this PR is the only in-flight change to external-request storage.

- **Partially implements #280** (Cosmos DB logical partition size limit on `*_v2` collections): this PR is the Phase-2 `_v3` cutover for `external_requests` only. It deviates deliberately from the issue's `{_id: 'hashed'}` proposal — the synthetic `partitionKey` keeps documents queryable per practice/day and still bounds every logical partition. `events_v2` and `internal_events_v2` remain to be done, so #280 **stays open**.
- **Builds on #302** (integration/practice context on external requests — all 5 phases merged): the `partitionKey` granularity comes directly from the `practiceId`/`integrationId` fields that #303 added. `ProviderExternalRequestsV3` extends the v2 entity, so v3 is born with both fields — exactly what #302's "Coordination with #280" section called for.
- **Enabled by nominal-systems/dmi-engine-common#25** (merged, 1.3.0) and its rollout: all five engine integrations adopted the `integrationId` propagation (idexx#59, antech-v6#62, wisdom-panel#23, antech#51, zoetis#33) and nominal-systems/dmi-engine#64 deployed it — so the `provider:na:day` fallback should be rare.
- **Supersedes (with #303) draft #297** (persist integrationId on external requests): #303 already landed that persistence on the v2 entity, and this PR moves writes to v3. #297 should be closed.
- **Partially addresses #215** (external requests/events archival strategy): v3 ships a configurable TTL (`EXTERNAL_REQUESTS_TTL_SECONDS`, default 30d) for external requests; the events half remains.
- **Compatible with nominal-systems/dmi-api-admin-ui#115** (merged): the admin UI reads external requests only through the dmi-api admin endpoints, and this PR's dual-read (v3 + v2) keeps those endpoints correct during the transition — no single-collection assumption in the UI.
- **Checked and unrelated:** branch `fix/event-hub-partition-key` sets a partition key on outgoing Event Hub messages for ordering (`event-subscription.service.ts`) — different subsystem, no overlap with this change.
