### PR TITLE
Do not file orphan results onto reports of guard-refused orders

### DIFF
--- a/src/common/utils/provider-result-utils.spec.ts
+++ b/src/common/utils/provider-result-utils.spec.ts
@@ -123,10 +123,16 @@ describe('ProviderResultUtils', () => {
       expect(ProviderResultUtils.isMatchingOrder(existing, extracted)).toBe(true)
     })
 
-    it('should return false when client last name is missing on either side', () => {
+    it('should return false when client last name is present on one side but missing on the other', () => {
       const existing = buildOrder({ integrationId: 'int-1', patientName: 'Toby', patientId: '123', clientLastName: 'Smith' })
       const extracted = buildOrder({ integrationId: 'int-1', patientName: 'Toby', patientId: '123' })
       expect(ProviderResultUtils.isMatchingOrder(existing, extracted)).toBe(false)
+    })
+
+    it('should skip the client check when absent on both sides (in-house analyzer results carry no client)', () => {
+      const existing = buildOrder({ integrationId: 'int-1', patientName: 'Toby', patientId: '123' })
+      const extracted = buildOrder({ integrationId: 'int-1', patientName: 'Toby', patientId: '123' })
+      expect(ProviderResultUtils.isMatchingOrder(existing, extracted)).toBe(true)
     })
 
     it('should return false when no fields are present to compare', () => {

--- a/src/common/utils/provider-result-utils.ts
+++ b/src/common/utils/provider-result-utils.ts
@@ -99,9 +99,15 @@ export class ProviderResultUtils {
       if (!existingPatientId || !extractedPatientId || existingPatientId !== extractedPatientId) return false
     }
 
-    // Check client last name — must be present and equal on both sides
-    if (!existingOrder.client?.lastName || !extractedOrder.client?.lastName) return false
-    if (existingOrder.client.lastName !== extractedOrder.client.lastName) return false
+    // Check client last name — if present on either side, both must have it and
+    // match. Absent on both sides is compatible: in-house analyzer results never
+    // carry a client, so requiring one would reject every same-run reconciliation
+    // and mint a new orphan order per poll.
+    const existingLastName = existingOrder.client?.lastName
+    const extractedLastName = extractedOrder.client?.lastName
+    if (existingLastName || extractedLastName) {
+      if (!existingLastName || !extractedLastName || existingLastName !== extractedLastName) return false
+    }
 
     return true
   }

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1796,6 +1796,7 @@ describe('ReportsService', () => {
         // #2: update report only
         jest.spyOn(ordersServiceMock, 'findOneByExternalId')
           .mockReturnValueOnce({
+            id: 'order-1',
             externalId: '20230330_155319_8501',
             integrationId: 'idexx',
             patient: { name: 'Toby', identifier: [] },
@@ -1803,9 +1804,10 @@ describe('ReportsService', () => {
           })
         jest.spyOn(reportsService, 'findReportsByExternalOrderIds')
           .mockResolvedValueOnce([])
-          .mockResolvedValueOnce([{
+        jest.spyOn(reportsService, 'findReportByOrderId')
+          .mockResolvedValueOnce({
             testResultsSet: []
-          } as unknown as Report])
+          } as unknown as Report)
         await reportsService.handleExternalResults({
           integrationId: 'idexx',
           results: externalResults
@@ -1867,16 +1869,20 @@ describe('ReportsService', () => {
         //   - Report should be updated and patient should be set
         const externalResultsB = FileUtils.loadFile('test/idexx/external_results-02b.json')
         const existingOrder = {
+          id: 'order-hope',
           integrationId: 'e025ab13-d6e6-4602-a935-72c2a8c8718e',
           externalId: '20230619_135522_8720',
           status: 'PARTIAL',
           patient: {
             name: 'Hope'
+          },
+          client: {
+            lastName: 'Larsen'
           }
         } as unknown as Order
         ordersServiceMock.findOneByExternalId.mockResolvedValueOnce(existingOrder)
         ordersServiceMock.getOrderFromProvider.mockResolvedValueOnce(null)
-        jest.spyOn(reportsService, 'findReportByExternalOrderId').mockImplementationOnce(async () => {
+        jest.spyOn(reportsService, 'findReportByOrderId').mockImplementationOnce(async () => {
           return {
             order: existingOrder,
             testResultsSet: []
@@ -1929,12 +1935,18 @@ describe('ReportsService', () => {
         // #2: update report for patient Baxter (Serology only), create report for Ty (Chemistry only)
         ordersServiceMock.findOneByExternalId
           .mockResolvedValueOnce({
+            id: 'order-baxter',
+            integrationId: 'e025ab13-d6e6-4602-a935-72c2a8c8718e',
+            externalId: '20230722_134823_8836',
             patient: {
               name: 'Baxter'
+            },
+            client: {
+              lastName: 'Bauguess'
             }
           })
           .mockResolvedValueOnce(null)
-        jest.spyOn(reportsService, 'findReportByExternalOrderId').mockImplementationOnce(async () => {
+        jest.spyOn(reportsService, 'findReportByOrderId').mockImplementationOnce(async () => {
           return {
             order: {
               externalId: '20230722_134823_8836',
@@ -2017,6 +2029,36 @@ describe('ReportsService', () => {
               ])
             })
           })
+        }))
+      })
+      it('should not reuse another order\'s report when the identity guard refuses the externalId match', async () => {
+        // A reused/typed externalId (e.g. a placeholder requisition id entered on
+        // an analyzer) can resolve to an order for a different patient. The guard
+        // refuses the order — the report lookup must not sneak the results onto
+        // that refused order's report through the shared externalId.
+        const externalResultsB = FileUtils.loadFile('test/idexx/external_results-02b.json')
+        ordersServiceMock.findOneByExternalId.mockResolvedValueOnce({
+          id: 'order-other-patient',
+          integrationId: 'e025ab13-d6e6-4602-a935-72c2a8c8718e',
+          externalId: '20230619_135522_8720',
+          patient: { name: 'Tinkerbell' },
+          client: { lastName: 'Bolland' }
+        } as unknown as Order)
+        const byOrderId = jest.spyOn(reportsService, 'findReportByOrderId')
+        const byExternalOrderId = jest.spyOn(reportsService, 'findReportByExternalOrderId')
+        await reportsService.handleExternalResults(externalResultsB)
+
+        // Fresh order + fresh report; no report lookup that could cross patients
+        expect(ordersServiceMock.saveOrder).toHaveBeenCalled()
+        expect(byOrderId).not.toHaveBeenCalled()
+        expect(byExternalOrderId).not.toHaveBeenCalled()
+        expect(eventsServiceMock.addEvent).toHaveBeenCalledWith(expect.objectContaining({
+          namespace: EventNamespace.REPORTS,
+          type: EventType.REPORT_CREATED
+        }))
+        expect(eventsServiceMock.addEvent).not.toHaveBeenCalledWith(expect.objectContaining({
+          namespace: EventNamespace.REPORTS,
+          type: EventType.REPORT_UPDATED
         }))
       })
       it('should set veterinarian for reports of test results', async () => {
@@ -2624,19 +2666,16 @@ describe('ReportsService', () => {
         const orphanResultsData = Object.assign({}, externalResult)
         // @ts-expect-error - trying to simulate orphan results
         delete orphanResultsData.results[0].orderId
-        jest.spyOn(reportsService, 'findReportByExternalOrderId').mockResolvedValueOnce({
-          order: {
-            externalId: 'WP-123'
-          },
-          testResultsSet: []
-        } as unknown as Report)
+        // A result with no order information reconciles into nothing: it gets a
+        // fresh order and a fresh report rather than reusing one by externalId.
+        ordersServiceMock.findOneByExternalId.mockResolvedValueOnce(null)
         await reportsService.handleExternalResults(externalResult)
 
         // TODO(gb): test that the PDF has in fact been attached to the report
 
         // It should not include the PDF data in the report event
         expect(eventsServiceMock.addEvent).toBeCalledWith(expect.objectContaining({
-          type: EventType.REPORT_UPDATED,
+          type: EventType.REPORT_CREATED,
           data: expect.objectContaining({
             report: expect.not.objectContaining({
               presentedForm: expect.any(Object)

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1,6 +1,6 @@
 import { forwardRef, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { FindManyOptions, Repository } from 'typeorm'
+import { FindManyOptions, Repository, SelectQueryBuilder } from 'typeorm'
 import { Report } from './entities/report.entity'
 import { FindOneOfTypeOptions, toFindOneOptions } from '../common/typings/find-one-of-type-options.interface'
 import { Order } from '../orders/entities/order.entity'
@@ -198,12 +198,19 @@ export class ReportsService {
         }
       }
 
+      const reconciledIntoExisting = order != null
       if (order == null) {
         order = await this.ordersService.saveOrder(extractedOrder)
         dummyOrders.push(order)
       }
       const patient = order.patient !== null ? order.patient : extractedOrder.patient
-      let report = await this.findReportByExternalOrderId(order.externalId, integrationId)
+      // Reuse only the report that belongs to the order we reconciled into.
+      // Resolving the report by externalId here can return a report attached to
+      // an order the guard above just refused, filing this result's observations
+      // onto another patient's report.
+      let report = reconciledIntoExisting
+        ? await this.findReportByOrderId(order.id)
+        : null
       if (report == null) {
         report = new Report()
         report.order = order
@@ -282,12 +289,8 @@ export class ReportsService {
     this.logger.log(`external_results -> Got ${results.length} results from ${integration.providerConfiguration.providerId}: ${createdReports.length} reports created, ${updatedReports.length} reports updated, orders ${[...createdOrders, ...dummyOrders].length} orders created`)
   }
 
-  async findReportsByExternalOrderIds (
-    externalOrderIds: string[],
-    integrationId?: string
-  ): Promise<Report[]> {
-    if (externalOrderIds.length === 0) return []
-    const query = this.reportsRepository.createQueryBuilder('report')
+  private reportGraphQuery (): SelectQueryBuilder<Report> {
+    return this.reportsRepository.createQueryBuilder('report')
       .leftJoinAndSelect('report.order', 'order')
       .leftJoinAndSelect('order.veterinarian', 'veterinarian')
       .leftJoinAndSelect('order.patient', 'patient')
@@ -299,16 +302,34 @@ export class ReportsService {
       .leftJoinAndSelect('report.patient', 'reportPatient')
       .leftJoinAndSelect('reportPatient.identifier', 'reportPatientIdentifier')
       .leftJoinAndSelect('testResult.observations', 'observation')
+      .orderBy('testResult.seq', 'ASC')
+      .addOrderBy('observation.seq', 'ASC')
+  }
+
+  async findReportsByExternalOrderIds (
+    externalOrderIds: string[],
+    integrationId?: string
+  ): Promise<Report[]> {
+    if (externalOrderIds.length === 0) return []
+    const query = this.reportGraphQuery()
       .where('order.externalId IN (:...externalOrderIds)', { externalOrderIds })
     // Scope by integration when known so a colliding externalId at a different OU
     // can't bind this OU's results onto another OU's report (issue #307).
     if (integrationId != null) {
       query.andWhere('order.integrationId = :integrationId', { integrationId })
     }
-    return await query
-      .orderBy('testResult.seq', 'ASC')
-      .addOrderBy('observation.seq', 'ASC')
+    return await query.getMany()
+  }
+
+  async findReportByOrderId (orderId: string): Promise<Report | undefined> {
+    const reports = await this.reportGraphQuery()
+      .where('order.id = :orderId', { orderId })
       .getMany()
+    if (reports.length === 1) {
+      return reports[0]
+    }
+
+    return undefined
   }
 
   async findReportByExternalOrderId (


### PR DESCRIPTION
## Problem

Since the v1.2.4 IDEXX engine restored the requisition-id fallback (#68 in `dmi-engine-idexx-integration`), in-house analyzer results that carry a typed requisition id (`000000`, `1234`, a pet name…) resolve to whatever older order already used that value as its `externalId`.

The identity guard in `handleExternalResults` correctly refuses to reconcile into that order when the patient/client doesn't match — but the report lookup right after it resolved the report **by the same externalId**, so the results were appended to the refused order's report anyway. Effects, confirmed in prod (2026-07-10 → 07-12):

- One orphan report accumulated results from **14 different patients** since July 1 (externalId `1234` at a single OU); another (`000000`) mixed two patients on July 10.
- These runs emit only `report:updated` on the old report — never `report:created` — so they **never surface in the VH Unmatched list**. ~90–120 analyzer runs/day are affected.
- Because analyzer results never carry a client and the guard required client last name on both sides, the guard could never pass — every poll of the same run also minted a fresh empty orphan order (4–5 shells per run).

## Fix

- Reuse a report only when we actually reconciled into an existing order, and only the report that **belongs to that order** (new `findReportByOrderId`). A guard-refused match now gets a fresh order **and a fresh report**, so `report:created` fires and the run shows up as unmatched with the correct patient.
- In `isMatchingOrder`, treat client last name **absent on both sides** as compatible (present-on-one-side still refuses). In-house analyzer results carry no client; patient-name equality plus the 60-minute orphan match window (#307) still bound the risk. This lets consecutive polls of the same run reconcile into the run's own order instead of minting one orphan per poll.

## Notes

- Companion engine-side fix (all-zeros placeholder sanitization) is merged but not yet released/deployed: nominal-systems/dmi-engine-idexx-integration#70. It covers only `000000`-style ids; this PR covers the general reused-externalId case.
- Two existing tests asserted the old funnel behavior (guard refuses, results still land on the refused order's report via externalId); they now model the corrected reconcile path. New regression test covers the guard-refused case end to end.
- `npx jest`: 22 suites, 185 tests pass.