### PR TITLE
Pin npm to 11.x in the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ ARG GHP_TOKEN
 
 COPY package*.json .npmrc ./
 
+# npm is pinned to 11.x: npm 12 enforces the install-scripts policy and blocks
+# argon2's node-pre-gyp install (no allowScripts config here yet), producing an
+# image without the native binding that crashes at boot. Move to npm 12 only
+# together with an allowScripts approval for argon2/sqlite3/msgpackr-extract.
 RUN apk add --no-cache --virtual build-base &&\
-    npm install -g npm node-gyp &&\
+    npm install -g npm@11 node-gyp &&\
     npm install &&\
     apk del build-base &&\
     npm un -g node-gyp &&\


### PR DESCRIPTION
## Problem

Build `1.0.0.913` (v1.14.4) crashes at boot in devv2 with:

```
Error: Cannot find module './lib/binding/napi-v3/argon2.node'
```

Both dmiapi pods are in CrashLoopBackOff. The code changes in v1.14.4 are unrelated — the app dies while loading `argon2`, before Nest starts.

## Root cause

The Dockerfile base stage runs `npm install -g npm` (unpinned). Between the v1.14.3 build (July 6) and the v1.14.4 build (July 13), npm 12.0.1 was released:

- **npm 11** (v1.14.3 build): warns `npm warn allow-scripts argon2@0.28.7 …` but still **runs** dependency install scripts → argon2's `node-pre-gyp install --fallback-to-build` downloads the native binding → working image (currently in prod).
- **npm 12** (v1.14.4 build): **enforces** the install-scripts policy — `4 packages had install scripts blocked because they are not covered by allowScripts`, including `argon2@0.28.7` → no binding in the image → crash at first `require('argon2')`.

Same Dockerfile, different day, different npm major.

## Fix

Pin the global npm install to `npm@11`, restoring the exact behavior that produced every working image so far. Comment in the Dockerfile explains why and what the follow-up is.

## Follow-up (separate change)

- Adopt npm 12's `allowScripts` approval for `argon2`, `sqlite3`, `msgpackr-extract` (and `@nestjs/core`'s harmless opencollective postinstall), then unpin.
- Note: `apk add --no-cache --virtual build-base` installs no packages (`build-base` is used as the virtual-group *name*), so the image has no compiler and native deps rely entirely on prebuilt-binary downloads from install scripts. Worth cleaning up alongside the allowScripts work.