### PR TITLE
Prevent duplicate order creation when events are processed concurrently

### DIFF
--- a/src/common/services/named-lock.service.spec.ts
+++ b/src/common/services/named-lock.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getDataSourceToken } from '@nestjs/typeorm'
+import { NamedLockService, orderLockKey } from './named-lock.service'
+
+describe('NamedLockService', () => {
+  let namedLockService: NamedLockService
+
+  const queryRunnerMock = {
+    query: jest.fn(),
+    release: jest.fn()
+  }
+  const dataSourceMock = {
+    options: { type: 'mysql' },
+    createQueryRunner: jest.fn(() => queryRunnerMock)
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NamedLockService,
+        {
+          provide: getDataSourceToken(),
+          useValue: dataSourceMock
+        }
+      ]
+    }).compile()
+
+    namedLockService = module.get<NamedLockService>(NamedLockService)
+    jest.clearAllMocks()
+    dataSourceMock.options.type = 'mysql'
+  })
+
+  it('should be defined', () => {
+    expect(namedLockService).toBeDefined()
+  })
+
+  describe('orderLockKey()', () => {
+    it('should build the same key for the same (integrationId, externalId) pair', () => {
+      expect(orderLockKey('integration-1', 'EXT-1')).toEqual('order:integration-1:EXT-1')
+    })
+  })
+
+  describe('withLock()', () => {
+    it('should acquire and release the lock on the same query runner around fn', async () => {
+      queryRunnerMock.query.mockResolvedValueOnce([{ acquired: 1 }])
+      const fn = jest.fn().mockResolvedValue('result')
+
+      const result = await namedLockService.withLock('key-1', fn)
+
+      expect(result).toEqual('result')
+      expect(fn).toHaveBeenCalled()
+      expect(queryRunnerMock.query).toHaveBeenNthCalledWith(
+        1,
+        'SELECT GET_LOCK(MD5(?), ?) AS acquired',
+        ['key-1', expect.any(Number)]
+      )
+      expect(queryRunnerMock.query).toHaveBeenNthCalledWith(
+        2,
+        'SELECT RELEASE_LOCK(MD5(?))',
+        ['key-1']
+      )
+      expect(queryRunnerMock.release).toHaveBeenCalled()
+    })
+
+    it('should run fn anyway when the lock wait times out', async () => {
+      queryRunnerMock.query.mockResolvedValueOnce([{ acquired: 0 }])
+      const fn = jest.fn().mockResolvedValue('result')
+
+      const result = await namedLockService.withLock('key-1', fn)
+
+      expect(result).toEqual('result')
+      expect(fn).toHaveBeenCalled()
+      // No RELEASE_LOCK for a lock that was never acquired
+      expect(queryRunnerMock.query).toHaveBeenCalledTimes(1)
+      expect(queryRunnerMock.release).toHaveBeenCalled()
+    })
+
+    it('should run fn anyway when acquiring the lock errors', async () => {
+      queryRunnerMock.query.mockRejectedValueOnce(new Error('connection lost'))
+      const fn = jest.fn().mockResolvedValue('result')
+
+      const result = await namedLockService.withLock('key-1', fn)
+
+      expect(result).toEqual('result')
+      expect(fn).toHaveBeenCalled()
+      expect(queryRunnerMock.release).toHaveBeenCalled()
+    })
+
+    it('should release the lock and the query runner when fn throws', async () => {
+      queryRunnerMock.query.mockResolvedValueOnce([{ acquired: 1 }])
+      const fn = jest.fn().mockRejectedValue(new Error('boom'))
+
+      await expect(namedLockService.withLock('key-1', fn)).rejects.toThrow('boom')
+
+      expect(queryRunnerMock.query).toHaveBeenNthCalledWith(
+        2,
+        'SELECT RELEASE_LOCK(MD5(?))',
+        ['key-1']
+      )
+      expect(queryRunnerMock.release).toHaveBeenCalled()
+    })
+
+    it('should skip locking on non-MySQL drivers', async () => {
+      dataSourceMock.options.type = 'sqlite'
+      const fn = jest.fn().mockResolvedValue('result')
+
+      const result = await namedLockService.withLock('key-1', fn)
+
+      expect(result).toEqual('result')
+      expect(dataSourceMock.createQueryRunner).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/common/services/named-lock.service.spec.ts
+++ b/src/common/services/named-lock.service.spec.ts
@@ -5,12 +5,16 @@ import { NamedLockService, orderLockKey } from './named-lock.service'
 describe('NamedLockService', () => {
   let namedLockService: NamedLockService
 
+  const queryRunnerManager = { name: 'queryRunnerManager' }
+  const defaultManager = { name: 'defaultManager' }
   const queryRunnerMock = {
     query: jest.fn(),
-    release: jest.fn()
+    release: jest.fn(),
+    manager: queryRunnerManager
   }
   const dataSourceMock = {
     options: { type: 'mysql' },
+    manager: defaultManager,
     createQueryRunner: jest.fn(() => queryRunnerMock)
   }
 
@@ -60,6 +64,9 @@ describe('NamedLockService', () => {
         ['key-1']
       )
       expect(queryRunnerMock.release).toHaveBeenCalled()
+      // The critical section runs on the query runner that holds the lock, so
+      // the find-or-create reuses that single connection (issue #320).
+      expect(fn).toHaveBeenCalledWith(queryRunnerManager)
     })
 
     it('should run fn anyway when the lock wait times out', async () => {
@@ -108,6 +115,8 @@ describe('NamedLockService', () => {
 
       expect(result).toEqual('result')
       expect(dataSourceMock.createQueryRunner).not.toHaveBeenCalled()
+      // Without a lock connection, fn falls back to the default manager.
+      expect(fn).toHaveBeenCalledWith(defaultManager)
     })
   })
 })

--- a/src/common/services/named-lock.service.ts
+++ b/src/common/services/named-lock.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { InjectDataSource } from '@nestjs/typeorm'
-import { DataSource } from 'typeorm'
+import { DataSource, EntityManager } from 'typeorm'
 
 /**
  * Lock key for order find-or-create sections. Using the same key format in
@@ -28,14 +28,18 @@ export class NamedLockService {
    * dedicated query runner is held for the duration of fn. If the process
    * dies while holding the lock, MySQL releases it when the connection drops.
    *
+   * fn receives the query runner's EntityManager and must run its critical-
+   * section queries through it, so the find-or-create reuses the connection
+   * already held for the lock instead of pinning a second pool connection.
+   *
    * If the lock cannot be acquired within the wait timeout, fn runs anyway
    * (graceful degradation to unserialized behavior, never worse than today).
    * On non-MySQL drivers (e.g. sqlite in tests) fn runs without locking.
    */
-  async withLock<T> (key: string, fn: () => Promise<T>): Promise<T> {
+  async withLock<T> (key: string, fn: (manager: EntityManager) => Promise<T>): Promise<T> {
     const driver = this.dataSource.options.type
     if (driver !== 'mysql' && driver !== 'mariadb') {
-      return await fn()
+      return await fn(this.dataSource.manager)
     }
 
     const queryRunner = this.dataSource.createQueryRunner()
@@ -53,7 +57,7 @@ export class NamedLockService {
       if (!acquired) {
         this.logger.warn(`Proceeding without named lock '${key}' after ${NamedLockService.LOCK_WAIT_SECONDS}s wait`)
       }
-      return await fn()
+      return await fn(queryRunner.manager)
     } finally {
       if (acquired) {
         try {

--- a/src/common/services/named-lock.service.ts
+++ b/src/common/services/named-lock.service.ts
@@ -1,0 +1,68 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectDataSource } from '@nestjs/typeorm'
+import { DataSource } from 'typeorm'
+
+/**
+ * Lock key for order find-or-create sections. Using the same key format in
+ * OrdersService and ReportsService makes external_results and external_orders
+ * handlers for the same order mutually exclusive (issue #320).
+ */
+export function orderLockKey (integrationId: string, externalId: string): string {
+  return `order:${integrationId}:${externalId}`
+}
+
+@Injectable()
+export class NamedLockService {
+  private readonly logger = new Logger(NamedLockService.name)
+  private static readonly LOCK_WAIT_SECONDS = 5
+
+  constructor (@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  /**
+   * Runs fn while holding a MySQL named lock, serializing critical sections
+   * across replicas that share the same database.
+   *
+   * The lock name is hashed with MD5 in SQL to stay under MySQL's 64-char
+   * lock-name limit. GET_LOCK and RELEASE_LOCK must run on the same pooled
+   * connection (releasing on a different one is a silent no-op), so a
+   * dedicated query runner is held for the duration of fn. If the process
+   * dies while holding the lock, MySQL releases it when the connection drops.
+   *
+   * If the lock cannot be acquired within the wait timeout, fn runs anyway
+   * (graceful degradation to unserialized behavior, never worse than today).
+   * On non-MySQL drivers (e.g. sqlite in tests) fn runs without locking.
+   */
+  async withLock<T> (key: string, fn: () => Promise<T>): Promise<T> {
+    const driver = this.dataSource.options.type
+    if (driver !== 'mysql' && driver !== 'mariadb') {
+      return await fn()
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner()
+    let acquired = false
+    try {
+      try {
+        const rows = await queryRunner.query(
+          'SELECT GET_LOCK(MD5(?), ?) AS acquired',
+          [key, NamedLockService.LOCK_WAIT_SECONDS]
+        )
+        acquired = Number(rows?.[0]?.acquired) === 1
+      } catch (error) {
+        this.logger.warn(`Error acquiring named lock '${key}': ${error.message}`)
+      }
+      if (!acquired) {
+        this.logger.warn(`Proceeding without named lock '${key}' after ${NamedLockService.LOCK_WAIT_SECONDS}s wait`)
+      }
+      return await fn()
+    } finally {
+      if (acquired) {
+        try {
+          await queryRunner.query('SELECT RELEASE_LOCK(MD5(?))', [key])
+        } catch (error) {
+          this.logger.warn(`Error releasing named lock '${key}': ${error.message}`)
+        }
+      }
+      await queryRunner.release()
+    }
+  }
+}

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -16,6 +16,7 @@ import { ReportsModule } from '../reports/reports.module'
 import { RefsModule } from '../refs/refs.module'
 import { ProvidersModule } from '../providers/providers.module'
 import { InternalEventLoggingModule } from '../internal-event-logging/internal-event-logging.module'
+import { NamedLockService } from '../common/services/named-lock.service'
 
 @Module({
   imports: [
@@ -30,7 +31,7 @@ import { InternalEventLoggingModule } from '../internal-event-logging/internal-e
     InternalEventLoggingModule
   ],
   controllers: [OrdersController],
-  providers: [OrdersService],
+  providers: [OrdersService, NamedLockService],
   exports: [OrdersService]
 })
 export class OrdersModule {}

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -950,6 +950,24 @@ describe('OrdersService', () => {
         expect(ordersRepositoryMock.save).not.toHaveBeenCalled()
         expect(eventsServiceMock.addEvent).not.toHaveBeenCalled()
       })
+
+      it('should propagate transient re-check errors instead of treating them as a missing order', async () => {
+        // A transient error during the re-check under the lock is NOT "order
+        // missing": proceeding would insert a duplicate of an order that may
+        // already exist (issue #320 review).
+        jest.spyOn(ordersRepositoryMock, 'find').mockResolvedValueOnce([])
+        jest.spyOn(ordersRepositoryMock, 'findOne').mockRejectedValueOnce(new Error('connection lost'))
+
+        await expect(
+          ordersService.handleExternalOrders({
+            integrationId: 'integration-1',
+            orders: [{ externalId: '123', status: 'SUBMITTED', tests: [] }] as any,
+          }),
+        ).rejects.toThrow('connection lost')
+
+        expect(ordersRepositoryMock.save).not.toHaveBeenCalled()
+        expect(eventsServiceMock.addEvent).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -30,6 +30,8 @@ import { v4 as uuidv4 } from 'uuid'
 import { Patient } from './entities/patient.entity'
 import { ProvidersService } from '../providers/services/providers.service'
 import { ExternalOrdersEventData } from '../common/typings/internal-event-data.interface'
+import { NamedLockService } from '../common/services/named-lock.service'
+import { In } from 'typeorm'
 
 export const repositoryMockFactory: () => MockUtils<Repository<any>> = jest.fn(() => ({
   find: jest.fn((entity) => entity),
@@ -86,6 +88,10 @@ describe('OrdersService', () => {
     checkLabRequisitionParameters: jest.fn(),
   }
 
+  const namedLockServiceMock = {
+    withLock: jest.fn(async (_key: string, fn: () => Promise<any>) => await fn()),
+  }
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -121,6 +127,10 @@ describe('OrdersService', () => {
         {
           provide: ProvidersService,
           useValue: providerServiceMock,
+        },
+        {
+          provide: NamedLockService,
+          useValue: namedLockServiceMock,
         },
         {
           provide: 'ACTIVEMQ',
@@ -751,10 +761,9 @@ describe('OrdersService', () => {
         // 1. Create new orders
         // Setup: do not find existing orders, create new ones
         jest.spyOn(ordersRepositoryMock, 'find').mockResolvedValueOnce([])
+        jest.spyOn(ordersRepositoryMock, 'findOne').mockResolvedValue(null)
         // @ts-expect-error: compiler type error
-        ordersRepositoryMock.create.mockImplementationOnce((data) =>
-          data.map((item, index) => Object.assign(new Order(), { ...item, id: index })),
-        )
+        ordersRepositoryMock.create.mockImplementation((item) => Object.assign(new Order(), item))
         // @ts-expect-error: compiler type error
         ordersRepositoryMock.save.mockImplementation(async (entities) => entities)
 
@@ -817,10 +826,9 @@ describe('OrdersService', () => {
 
       it('should attach manifest to new orders', async () => {
         jest.spyOn(ordersRepositoryMock, 'find').mockResolvedValueOnce([])
+        jest.spyOn(ordersRepositoryMock, 'findOne').mockResolvedValue(null)
         // @ts-expect-error: compiler type error
-        ordersRepositoryMock.create.mockImplementationOnce((data) =>
-          data.map((item) => Object.assign(new Order(), item)),
-        )
+        ordersRepositoryMock.create.mockImplementation((item) => Object.assign(new Order(), item))
         // @ts-expect-error: compiler type error
         ordersRepositoryMock.save.mockImplementation(async (entities) => entities)
 
@@ -870,10 +878,9 @@ describe('OrdersService', () => {
 
       it('should not attach manifest if none provided', async () => {
         jest.spyOn(ordersRepositoryMock, 'find').mockResolvedValueOnce([])
+        jest.spyOn(ordersRepositoryMock, 'findOne').mockResolvedValue(null)
         // @ts-expect-error: compiler type error
-        ordersRepositoryMock.create.mockImplementationOnce((data) =>
-          data.map((item) => Object.assign(new Order(), item)),
-        )
+        ordersRepositoryMock.create.mockImplementation((item) => Object.assign(new Order(), item))
         // @ts-expect-error: compiler type error
         ordersRepositoryMock.save.mockImplementation(async (entities) => entities)
 
@@ -901,6 +908,73 @@ describe('OrdersService', () => {
           }),
         )
       })
+    })
+
+    describe('concurrent creation (issue #320)', () => {
+      it('should serialize order creation with a named lock per (integrationId, externalId)', async () => {
+        jest.spyOn(ordersRepositoryMock, 'find').mockResolvedValueOnce([])
+        jest.spyOn(ordersRepositoryMock, 'findOne').mockResolvedValue(null)
+        // @ts-expect-error: compiler type error
+        ordersRepositoryMock.create.mockImplementation((item) => Object.assign(new Order(), item))
+        // @ts-expect-error: compiler type error
+        ordersRepositoryMock.save.mockImplementation(async (entities) => entities)
+
+        await ordersService.handleExternalOrders({
+          integrationId: 'integration-1',
+          orders: [{ externalId: '123', status: 'SUBMITTED', tests: [] }] as any,
+        })
+
+        expect(namedLockServiceMock.withLock).toHaveBeenCalledWith(
+          'order:integration-1:123',
+          expect.any(Function),
+        )
+        expect(eventsServiceMock.addEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ type: EventType.ORDER_CREATED }),
+        )
+      })
+
+      it('should not create a duplicate order when it was created concurrently', async () => {
+        // Batch lookup misses the order, but the re-check under the lock finds it:
+        // another handler created it while this one was waiting for the lock.
+        jest.spyOn(ordersRepositoryMock, 'find').mockResolvedValueOnce([])
+        jest.spyOn(ordersRepositoryMock, 'findOne').mockResolvedValue({
+          id: 'winner-order',
+          externalId: '123',
+        } as Order)
+
+        await ordersService.handleExternalOrders({
+          integrationId: 'integration-1',
+          orders: [{ externalId: '123', status: 'SUBMITTED', tests: [] }] as any,
+        })
+
+        expect(ordersRepositoryMock.save).not.toHaveBeenCalled()
+        expect(eventsServiceMock.addEvent).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('findOrdersByExternalIds()', () => {
+    it('should scope the lookup by integration when known (issue #320)', async () => {
+      await ordersService.findOrdersByExternalIds(['A-1'], 'integration-1')
+
+      expect(ordersRepositoryMock.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: [
+            { externalId: In(['A-1']), integrationId: 'integration-1' },
+            { requisitionId: In(['A-1']), integrationId: 'integration-1' },
+          ],
+        }),
+      )
+    })
+
+    it('should keep the global lookup when no integration is given', async () => {
+      await ordersService.findOrdersByExternalIds(['A-1'])
+
+      expect(ordersRepositoryMock.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: [{ externalId: In(['A-1']) }, { requisitionId: In(['A-1']) }],
+        }),
+      )
     })
   })
 

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common'
 import { ClientProxy } from '@nestjs/microservices'
 import { InjectRepository } from '@nestjs/typeorm'
-import { FindManyOptions, In, Repository } from 'typeorm'
+import { EntityManager, FindManyOptions, In, Repository } from 'typeorm'
 import { IntegrationsService } from '../integrations/integrations.service'
 import { CreateOrderDto } from './dtos/create-order.dto'
 import { Order } from './entities/order.entity'
@@ -76,6 +76,14 @@ export class OrdersService {
     return await this.ordersRepository.find(options)
   }
 
+  // Resolve the repository to use for a find-or-create: when running inside a
+  // NamedLockService critical section, the passed EntityManager is bound to the
+  // connection that already holds the lock, so reusing it keeps the section on a
+  // single pool connection instead of checking out a second one (issue #320).
+  private orderRepo(manager?: EntityManager): Repository<Order> {
+    return manager != null ? manager.getRepository(Order) : this.ordersRepository
+  }
+
   async searchOrders(
     organizationId: string,
     {
@@ -120,8 +128,8 @@ export class OrdersService {
     return await qb.getMany()
   }
 
-  async findOne(args: FindOneOfTypeOptions<Order>): Promise<Order> {
-    const order = await this.ordersRepository.findOne(toFindOneOptions(args))
+  async findOne(args: FindOneOfTypeOptions<Order>, manager?: EntityManager): Promise<Order> {
+    const order = await this.orderRepo(manager).findOne(toFindOneOptions(args))
 
     if (order == null) {
       throw new NotFoundException('The order was not found')
@@ -499,12 +507,12 @@ export class OrdersService {
       // twice (issue #320).
       const newOrder = await this.namedLockService.withLock(
         orderLockKey(integrationId, externalOrder.externalId),
-        async () => {
+        async (manager) => {
           // Re-check under the lock: the order may have been created between the
           // batch lookup above and here.
           let existing: Order | null = null
           try {
-            existing = await this.findOneByExternalId(externalOrder.externalId, integrationId)
+            existing = await this.findOneByExternalId(externalOrder.externalId, integrationId, manager)
           } catch (error) {
             existing = null
           }
@@ -514,9 +522,8 @@ export class OrdersService {
             )
             return null
           }
-          return await this.ordersRepository.save(
-            this.ordersRepository.create(mapper.mapOrder(externalOrder, integrationId)),
-          )
+          const repo = this.orderRepo(manager)
+          return await repo.save(repo.create(mapper.mapOrder(externalOrder, integrationId)))
         },
       )
       if (newOrder != null) {
@@ -689,7 +696,7 @@ export class OrdersService {
     return manifest
   }
 
-  async findOneByExternalId(externalId: string, integrationId?: string): Promise<Order> {
+  async findOneByExternalId(externalId: string, integrationId?: string, manager?: EntityManager): Promise<Order> {
     // Scope the lookup by integration when known so a colliding externalId at a
     // different OU can't be returned (issue #307). Callers without an
     // integration context (e.g. admin tooling) keep the global lookup.
@@ -709,7 +716,7 @@ export class OrdersService {
           'client.identifier',
         ],
       },
-    })
+    }, manager)
   }
 
   async findOrdersByExternalIds(externalIds: string[], integrationId?: string): Promise<Order[]> {
@@ -754,12 +761,11 @@ export class OrdersService {
     return await this.client.send(messagePattern, message).toPromise()
   }
 
-  async createExternalOrder(integrationId, externalOrder: ExternalOrder): Promise<Order> {
+  async createExternalOrder(integrationId, externalOrder: ExternalOrder, manager?: EntityManager): Promise<Order> {
+    const repo = this.orderRepo(manager)
     const mapper = new ExternalOrderMapper()
-    const createdOrders = this.ordersRepository.create(
-      mapper.mapOrder(externalOrder, integrationId),
-    )
-    return await this.ordersRepository.save(createdOrders)
+    const createdOrders = repo.create(mapper.mapOrder(externalOrder, integrationId))
+    return await repo.save(createdOrders)
   }
 
   async updateOrderFromResults(order: Order, result: ProviderResult): Promise<boolean> {
@@ -792,9 +798,10 @@ export class OrdersService {
     return order
   }
 
-  async saveOrder(order: Order): Promise<Order> {
-    const createdOrder = this.ordersRepository.create(order)
-    return await this.ordersRepository.save(createdOrder)
+  async saveOrder(order: Order, manager?: EntityManager): Promise<Order> {
+    const repo = this.orderRepo(manager)
+    const createdOrder = repo.create(order)
+    return await repo.save(createdOrder)
   }
 
   async countByProvider(start: Date, end: Date): Promise<any> {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -514,6 +514,10 @@ export class OrdersService {
           try {
             existing = await this.findOneByExternalId(externalOrder.externalId, integrationId, manager)
           } catch (error) {
+            // Only "not found" means missing: a transient error must abort the
+            // event instead of being treated as missing, which would insert a
+            // duplicate of an order that may already exist (issue #320 review).
+            if (!(error instanceof NotFoundException)) throw error
             existing = null
           }
           if (existing != null) {

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -44,6 +44,7 @@ import {
   ExternalOrdersEventData,
   ExternalResultEventData,
 } from '../common/typings/internal-event-data.interface'
+import { NamedLockService, orderLockKey } from '../common/services/named-lock.service'
 
 interface OrderTestCancelOrAddParams {
   orderId: string
@@ -65,6 +66,7 @@ export class OrdersService {
     @Inject(EventsService) private readonly eventsService: EventsService,
     @Inject(RefsService) private readonly refsService: RefsService,
     @Inject(ProvidersService) private readonly providersService: ProvidersService,
+    @Inject(NamedLockService) private readonly namedLockService: NamedLockService,
     @Inject('ACTIVEMQ') private readonly client: ClientProxy,
   ) {
     this.nodeEnv = this.configService.get('nodeEnv')
@@ -461,7 +463,7 @@ export class OrdersService {
     const externalOrdersIds = orders.map((order) => order.externalId)
 
     // Handle existing orders
-    const existingOrders = await this.findOrdersByExternalIds(externalOrdersIds)
+    const existingOrders = await this.findOrdersByExternalIds(externalOrdersIds, integrationId)
     const updatedOrders: Order[] = []
     for (const existingOrder of existingOrders) {
       const externalOrder = orders.find((order) => order.externalId === existingOrder.externalId)
@@ -484,27 +486,53 @@ export class OrdersService {
     const mapper = new ExternalOrderMapper()
     const existingOrdersExternalIds = existingOrders.map((order) => order.externalId)
     const existingOrdersRequisitionIds = existingOrders.map((order) => order.requisitionId)
-    const nonExistingOrders = orders
-      .filter(
-        (order) =>
-          !existingOrdersExternalIds.includes(order.externalId) &&
-          !existingOrdersRequisitionIds.includes(order.externalId),
+    const nonExistingExternalOrders = orders.filter(
+      (order) =>
+        !existingOrdersExternalIds.includes(order.externalId) &&
+        !existingOrdersRequisitionIds.includes(order.externalId),
+    )
+
+    const newOrders: Order[] = []
+    for (const externalOrder of nonExistingExternalOrders) {
+      // Serialize find-or-create per (integrationId, externalId) so a concurrent
+      // external_results/external_orders handler can't insert the same order
+      // twice (issue #320).
+      const newOrder = await this.namedLockService.withLock(
+        orderLockKey(integrationId, externalOrder.externalId),
+        async () => {
+          // Re-check under the lock: the order may have been created between the
+          // batch lookup above and here.
+          let existing: Order | null = null
+          try {
+            existing = await this.findOneByExternalId(externalOrder.externalId, integrationId)
+          } catch (error) {
+            existing = null
+          }
+          if (existing != null) {
+            this.logger.debug(
+              `Order ${externalOrder.externalId} was created concurrently, skipping creation`,
+            )
+            return null
+          }
+          return await this.ordersRepository.save(
+            this.ordersRepository.create(mapper.mapOrder(externalOrder, integrationId)),
+          )
+        },
       )
-      .map((order) => mapper.mapOrder(order, integrationId))
-    const newOrders = this.ordersRepository.create(nonExistingOrders)
-    const allOrders = [...newOrders, ...updatedOrders]
+      if (newOrder != null) {
+        newOrders.push(newOrder)
+      }
+    }
 
     // Nothing to do, return
-    if (allOrders.length === 0) {
+    if (newOrders.length === 0 && updatedOrders.length === 0) {
       this.logger.debug(`Got ${orders.length} external orders: 0 created, 0 updated`)
       return
     }
 
     // Notify about new orders
     const integration = await this.integrationsService.findById(integrationId)
-    for (const order of newOrders) {
-      // TODO(gb): make this more efficient by saving in batch
-      const newOrder = await this.ordersRepository.save(order)
+    for (const newOrder of newOrders) {
       await this.eventsService.addEvent({
         namespace: EventNamespace.ORDERS,
         type: EventType.ORDER_CREATED,
@@ -684,7 +712,11 @@ export class OrdersService {
     })
   }
 
-  async findOrdersByExternalIds(externalIds: string[]): Promise<Order[]> {
+  async findOrdersByExternalIds(externalIds: string[], integrationId?: string): Promise<Order[]> {
+    // Scope by integration when known so a colliding externalId at a different
+    // OU can't cross-match another OU's orders (issues #307/#320). Callers
+    // without an integration context (e.g. event logging) keep the global lookup.
+    const scope = integrationId != null ? { integrationId } : {}
     return await this.findAll({
       relations: [
         'patient',
@@ -694,7 +726,10 @@ export class OrdersService {
         'tests',
         'client.identifier',
       ],
-      where: [{ externalId: In(externalIds) }, { requisitionId: In(externalIds) }],
+      where: [
+        { externalId: In(externalIds), ...scope },
+        { requisitionId: In(externalIds), ...scope },
+      ],
     })
   }
 

--- a/src/reports/reports.module.ts
+++ b/src/reports/reports.module.ts
@@ -12,6 +12,7 @@ import { InternalEventLoggingModule } from '../internal-event-logging/internal-e
 import { FEATURE_FLAG_PROVIDER } from '../feature-flags/feature-flag.interface'
 import { StatsigFeatureFlagProvider } from '../feature-flags/statsig-feature-flag.provider'
 import { EnvFeatureFlagProvider } from '../feature-flags/env-feature-flag.provider'
+import { NamedLockService } from '../common/services/named-lock.service'
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { EnvFeatureFlagProvider } from '../feature-flags/env-feature-flag.provid
   controllers: [ReportsController],
   providers: [
     ReportsService,
+    NamedLockService,
 {
       provide: FEATURE_FLAG_PROVIDER,
       useClass: process.env.STATSIG_ENABLED === 'true' ? StatsigFeatureFlagProvider : EnvFeatureFlagProvider

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -2138,6 +2138,39 @@ describe('ReportsService', () => {
         }))
         jest.clearAllMocks()
       })
+      it('should not create an order when the re-check under the lock fails transiently (issue #320)', async () => {
+        // A transient error during the re-check is NOT "order missing":
+        // treating it as such would insert a duplicate of an order that may
+        // already exist.
+        const externalOrder = { externalId: 'EXT-1', status: 'COMPLETED' }
+        jest.spyOn(reportsService, 'findReportsByExternalOrderIds').mockResolvedValueOnce([])
+        ordersServiceMock.findOrdersByExternalIds.mockResolvedValueOnce([])
+        ordersServiceMock.getOrderFromProvider.mockResolvedValueOnce(externalOrder)
+        ordersServiceMock.findOneByExternalId.mockRejectedValueOnce(new Error('connection lost'))
+
+        await reportsService.handleExternalResults({
+          integrationId: 'idexx',
+          results: [{ id: 'r1', orderId: 'EXT-1', status: 'COMPLETED', testResults: [] }] as unknown as ProviderResult[]
+        })
+
+        expect(ordersServiceMock.createExternalOrder).not.toHaveBeenCalled()
+        expect(eventsServiceMock.addEvent).not.toHaveBeenCalledWith(expect.objectContaining({
+          type: EventType.ORDER_CREATED
+        }))
+        jest.clearAllMocks()
+      })
+      it('should propagate transient re-check errors for orphan results instead of creating a spurious order (issue #320)', async () => {
+        // A transient error during the orphan re-check under the lock is NOT
+        // "order missing": treating it as such would insert a spurious new
+        // order for the orphan result.
+        const externalResultsA = FileUtils.loadFile('test/idexx/external_results-02a.json')
+        ordersServiceMock.findOneByExternalId.mockRejectedValueOnce(new Error('connection lost'))
+
+        await expect(reportsService.handleExternalResults(externalResultsA)).rejects.toThrow('connection lost')
+
+        expect(ordersServiceMock.saveOrder).not.toHaveBeenCalled()
+        jest.clearAllMocks()
+      })
     })
     describe('Antech', () => {
       it('should create orders/reports', async () => {

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -18,6 +18,7 @@ import { HttpException, HttpStatus } from '@nestjs/common'
 import { ExternalResultEventData } from '../common/typings/internal-event-data.interface'
 import { TestResultItemInterpretationCode } from '@nominal-systems/dmi-engine-common'
 import { FEATURE_FLAG_PROVIDER } from '../feature-flags/feature-flag.interface'
+import { NamedLockService } from '../common/services/named-lock.service'
 
 const repositoryMockFactory: () => MockUtils<Repository<any>> = jest.fn(() => ({
   findOne: jest.fn(entity => entity),
@@ -38,6 +39,7 @@ describe('ReportsService', () => {
     }),
     saveOrder: jest.fn().mockImplementation((order) => order),
     createExternalOrder: jest.fn().mockImplementation((integrationId, order) => order),
+    updateOrderFromResults: jest.fn(),
     updateOrderStatusFromResults: jest.fn().mockImplementation((order) => order)
   }
   const integrationsServiceMock = {
@@ -53,6 +55,9 @@ describe('ReportsService', () => {
   }
   const eventsServiceMock = {
     addEvent: jest.fn()
+  }
+  const namedLockServiceMock = {
+    withLock: jest.fn(async (_key: string, fn: () => Promise<any>) => await fn())
   }
 
   beforeEach(async () => {
@@ -82,6 +87,10 @@ describe('ReportsService', () => {
         {
           provide: FEATURE_FLAG_PROVIDER,
           useValue: { isEnabled: jest.fn().mockReturnValue(false) }
+        },
+        {
+          provide: NamedLockService,
+          useValue: namedLockServiceMock
         }
       ]
     }).compile()
@@ -2100,6 +2109,35 @@ describe('ReportsService', () => {
           jest.clearAllMocks()
         }).not.toThrow()
       })
+      it('should reuse a concurrently created order instead of creating a duplicate (issue #320)', async () => {
+        const externalOrder = { externalId: 'EXT-1', status: 'COMPLETED' }
+        const existingOrder = { id: 'winner-order', externalId: 'EXT-1' } as unknown as Order
+        jest.spyOn(reportsService, 'findReportsByExternalOrderIds').mockResolvedValueOnce([])
+        ordersServiceMock.findOrdersByExternalIds.mockResolvedValueOnce([])
+        ordersServiceMock.getOrderFromProvider.mockResolvedValueOnce(externalOrder)
+        // The re-check under the lock finds the order the concurrent handler created
+        ordersServiceMock.findOneByExternalId.mockResolvedValueOnce(existingOrder)
+
+        await reportsService.handleExternalResults({
+          integrationId: 'idexx',
+          results: [{ id: 'r1', orderId: 'EXT-1', status: 'COMPLETED', testResults: [] }] as unknown as ProviderResult[]
+        })
+
+        expect(namedLockServiceMock.withLock).toHaveBeenCalledWith('order:idexx:EXT-1', expect.any(Function))
+        expect(ordersServiceMock.createExternalOrder).not.toHaveBeenCalled()
+        expect(eventsServiceMock.addEvent).not.toHaveBeenCalledWith(expect.objectContaining({
+          type: EventType.ORDER_CREATED
+        }))
+        // The result is still filed onto a report for the winner's order
+        expect(eventsServiceMock.addEvent).toHaveBeenCalledWith(expect.objectContaining({
+          namespace: EventNamespace.REPORTS,
+          type: EventType.REPORT_CREATED,
+          data: expect.objectContaining({
+            orderId: 'winner-order'
+          })
+        }))
+        jest.clearAllMocks()
+      })
     })
     describe('Antech', () => {
       it('should create orders/reports', async () => {
@@ -2517,6 +2555,8 @@ describe('ReportsService', () => {
         const results: ProviderResult[] = FileUtils.loadFile('test/heska/heska-results-batch-01.json')
         jest.spyOn(reportsService, 'findReportsByExternalOrderIds').mockResolvedValueOnce([])
         jest.spyOn(ordersServiceMock, 'findOrdersByExternalIds').mockResolvedValue([])
+        // The re-check under the find-or-create lock must miss for the order to be created
+        jest.spyOn(ordersServiceMock, 'findOneByExternalId').mockResolvedValueOnce(null)
         jest.spyOn(ordersServiceMock, 'getOrderFromProvider').mockResolvedValue({
           externalId: 'DMI-DR94877',
           status: 'COMPLETED'

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -174,6 +174,10 @@ export class ReportsService {
             try {
               existing = await this.ordersService.findOneByExternalId(externalOrderId, integrationId, manager)
             } catch (error) {
+              // Only "not found" means missing: a transient error must skip
+              // this order instead of being treated as missing, which would
+              // insert a duplicate (issue #320 review).
+              if (!(error instanceof NotFoundException)) throw error
               existing = null
             }
             if (existing != null) {
@@ -215,6 +219,10 @@ export class ReportsService {
           try {
             order = await this.ordersService.findOneByExternalId(extractedOrder.externalId, integrationId, manager)
           } catch (err) {
+            // Only "not found" means missing: a transient error must abort the
+            // event instead of being treated as missing, which would insert a
+            // spurious new order for the orphan result (issue #320 review).
+            if (!(err instanceof NotFoundException)) throw err
             order = null
           }
 

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -26,6 +26,7 @@ import { isNullOrEmpty } from '../common/utils/shared.utils'
 import { Attachment as AttachmentEntity } from '../common/entities/attachment.entity'
 import { ExternalResultEventData } from '../common/typings/internal-event-data.interface'
 import { FEATURE_FLAG_PROVIDER, FeatureFlagProvider, TEST_RESULT_MATCH_BY_NAME_FLAG } from '../feature-flags/feature-flag.interface'
+import { NamedLockService, orderLockKey } from '../common/services/named-lock.service'
 
 @Injectable()
 export class ReportsService {
@@ -37,7 +38,8 @@ export class ReportsService {
     @Inject(forwardRef(() => OrdersService)) private readonly ordersService: OrdersService,
     @Inject(IntegrationsService) private readonly integrationsService: IntegrationsService,
     @Inject(EventsService) private readonly eventsService: EventsService,
-    @Inject(FEATURE_FLAG_PROVIDER) private readonly featureFlags: FeatureFlagProvider
+    @Inject(FEATURE_FLAG_PROVIDER) private readonly featureFlags: FeatureFlagProvider,
+    @Inject(NamedLockService) private readonly namedLockService: NamedLockService
   ) {
   }
 
@@ -148,19 +150,47 @@ export class ReportsService {
     // Create external orders
     const externalOrders: ExternalOrder[] = []
     const nonExistingReportExternalOrderIds = arrayDiff(externalOrderIds, existingReports.map(report => report.order.externalId))
-    const nonExistingReportOrders = await this.ordersService.findOrdersByExternalIds(nonExistingReportExternalOrderIds)
+    const nonExistingReportOrders = await this.ordersService.findOrdersByExternalIds(nonExistingReportExternalOrderIds, integrationId)
     const nonExistingOrderExternalIds = arrayDiff(nonExistingReportExternalOrderIds, nonExistingReportOrders.map(order => order.externalId))
     for (const externalOrderId of nonExistingOrderExternalIds) {
       try {
+        // The provider fetch stays outside the lock: it can take seconds of HTTP
+        // and must not pin a pool connection while holding the lock.
         const externalOrder = await this.ordersService.getOrderFromProvider(externalOrderId, integration.providerConfiguration, integration.integrationOptions, integration.id)
         if (externalOrder == null) {
           this.logger.warn(`Order from provider not found -> External ID: ${externalOrderId}`)
           continue
         }
         this.logger.debug(`Getting order from provider -> External ID: ${externalOrderId}`)
-        const order = await this.ordersService.createExternalOrder(integrationId, externalOrder)
-        createdOrders.push(order)
-        const resultForOrder = results.filter(result => result.orderId === order.externalId)
+        // Serialize find-or-create per (integrationId, externalId) so a concurrent
+        // external_results/external_orders handler can't insert the same order
+        // twice (issue #320).
+        const { order, created } = await this.namedLockService.withLock(
+          orderLockKey(integrationId, externalOrderId),
+          async () => {
+            // Re-check under the lock: the order may have been created between
+            // the batch lookup above and here.
+            let existing: Order | null = null
+            try {
+              existing = await this.ordersService.findOneByExternalId(externalOrderId, integrationId)
+            } catch (error) {
+              existing = null
+            }
+            if (existing != null) {
+              return { order: existing, created: false }
+            }
+            return { order: await this.ordersService.createExternalOrder(integrationId, externalOrder), created: true }
+          }
+        )
+        if (created) {
+          createdOrders.push(order)
+        } else {
+          // The order was created concurrently by another handler: skip the
+          // ORDER_CREATED event but still create its report below.
+          this.logger.debug(`Order for external ID ${externalOrderId} was created concurrently, reusing Order/${order.id}`)
+          nonExistingReportOrders.push(order)
+        }
+        const resultForOrder = results.filter(result => result.orderId === externalOrderId)
         await this.ordersService.updateOrderFromResults(order, resultForOrder[0])
         externalOrders.push(externalOrder)
       } catch (error) {
@@ -174,35 +204,44 @@ export class ReportsService {
     for (const orphanResult of orphanResults) {
       const extractedOrder: Order = ProviderResultUtils.extractOrderFromOrphanResult(orphanResult, integrationId)
 
-      // Finding if order exists and saving order are done in parallel to improve performance.
-      let order: Order | null
-      try {
-        order = await this.ordersService.findOneByExternalId(extractedOrder.externalId, integrationId)
-      } catch (err) {
-        order = null
-      }
+      // Serialize find-or-create per (integrationId, externalId) so two concurrent
+      // handlers can't both miss the lookup and insert the same order twice
+      // (issue #320). The loser of the race sees the winner's order and the #307
+      // window logic below decides whether to reconcile into it or create a new one.
+      const { order, reconciledIntoExisting } = await this.namedLockService.withLock(
+        orderLockKey(integrationId, extractedOrder.externalId),
+        async () => {
+          let order: Order | null
+          try {
+            order = await this.ordersService.findOneByExternalId(extractedOrder.externalId, integrationId)
+          } catch (err) {
+            order = null
+          }
 
-      this.logger.debug(`Orphan externalId=${extractedOrder.externalId}, existingOrder=${order?.id}, existingPatient=${order?.patient?.name}, extractedPatient=${extractedOrder.patient?.name}, existingClient=${order?.client?.lastName}, extractedClient=${extractedOrder.client?.lastName}`)
+          this.logger.debug(`Orphan externalId=${extractedOrder.externalId}, existingOrder=${order?.id}, existingPatient=${order?.patient?.name}, extractedPatient=${extractedOrder.patient?.name}, existingClient=${order?.client?.lastName}, extractedClient=${extractedOrder.client?.lastName}`)
 
-      // Reconcile into the existing order only when the patient/client identity
-      // matches AND the order's externalId wasn't reused for a different episode
-      // beyond the match window (issue #307). Otherwise create a new order so a
-      // reused placeholder/pet-name externalId doesn't blend distinct patients.
-      if (order != null) {
-        const mismatch = !ProviderResultUtils.isMatchingOrder(order, extractedOrder)
-        const staleReuse = ProviderResultUtils.isStaleOrphanMatch(order)
-        if (mismatch || staleReuse) {
-          const reason = mismatch ? 'patient/client mismatch' : 'stale orphan externalId reuse'
-          this.logger.warn(`Orphan result externalId ${extractedOrder.externalId} matched order ${order.id} but ${reason}. Creating new order.`)
-          order = null
+          // Reconcile into the existing order only when the patient/client identity
+          // matches AND the order's externalId wasn't reused for a different episode
+          // beyond the match window (issue #307). Otherwise create a new order so a
+          // reused placeholder/pet-name externalId doesn't blend distinct patients.
+          if (order != null) {
+            const mismatch = !ProviderResultUtils.isMatchingOrder(order, extractedOrder)
+            const staleReuse = ProviderResultUtils.isStaleOrphanMatch(order)
+            if (mismatch || staleReuse) {
+              const reason = mismatch ? 'patient/client mismatch' : 'stale orphan externalId reuse'
+              this.logger.warn(`Orphan result externalId ${extractedOrder.externalId} matched order ${order.id} but ${reason}. Creating new order.`)
+              order = null
+            }
+          }
+
+          const reconciledIntoExisting = order != null
+          if (order == null) {
+            order = await this.ordersService.saveOrder(extractedOrder)
+            dummyOrders.push(order)
+          }
+          return { order, reconciledIntoExisting }
         }
-      }
-
-      const reconciledIntoExisting = order != null
-      if (order == null) {
-        order = await this.ordersService.saveOrder(extractedOrder)
-        dummyOrders.push(order)
-      }
+      )
       const patient = order.patient !== null ? order.patient : extractedOrder.patient
       // Reuse only the report that belongs to the order we reconciled into.
       // Resolving the report by externalId here can return a report attached to

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -167,19 +167,19 @@ export class ReportsService {
         // twice (issue #320).
         const { order, created } = await this.namedLockService.withLock(
           orderLockKey(integrationId, externalOrderId),
-          async () => {
+          async (manager) => {
             // Re-check under the lock: the order may have been created between
             // the batch lookup above and here.
             let existing: Order | null = null
             try {
-              existing = await this.ordersService.findOneByExternalId(externalOrderId, integrationId)
+              existing = await this.ordersService.findOneByExternalId(externalOrderId, integrationId, manager)
             } catch (error) {
               existing = null
             }
             if (existing != null) {
               return { order: existing, created: false }
             }
-            return { order: await this.ordersService.createExternalOrder(integrationId, externalOrder), created: true }
+            return { order: await this.ordersService.createExternalOrder(integrationId, externalOrder, manager), created: true }
           }
         )
         if (created) {
@@ -210,10 +210,10 @@ export class ReportsService {
       // window logic below decides whether to reconcile into it or create a new one.
       const { order, reconciledIntoExisting } = await this.namedLockService.withLock(
         orderLockKey(integrationId, extractedOrder.externalId),
-        async () => {
+        async (manager) => {
           let order: Order | null
           try {
-            order = await this.ordersService.findOneByExternalId(extractedOrder.externalId, integrationId)
+            order = await this.ordersService.findOneByExternalId(extractedOrder.externalId, integrationId, manager)
           } catch (err) {
             order = null
           }
@@ -236,7 +236,7 @@ export class ReportsService {
 
           const reconciledIntoExisting = order != null
           if (order == null) {
-            order = await this.ordersService.saveOrder(extractedOrder)
+            order = await this.ordersService.saveOrder(extractedOrder, manager)
             dummyOrders.push(order)
           }
           return { order, reconciledIntoExisting }

--- a/test/e2e/named-lock.e2e-spec.ts
+++ b/test/e2e/named-lock.e2e-spec.ts
@@ -1,0 +1,199 @@
+import { Connection, createConnection } from 'typeorm'
+import { NamedLockService, orderLockKey } from '../../src/common/services/named-lock.service'
+
+const TEST_DB = 'dmi_named_lock_test'
+
+const baseConfig = {
+  type: 'mysql' as const,
+  host: process.env.DATABASE_HOST ?? 'localhost',
+  port: Number(process.env.DATABASE_PORT ?? 3306),
+  username: process.env.DATABASE_USERNAME ?? 'root',
+  password: process.env.DATABASE_PASSWORD ?? 'asdf1234',
+}
+
+const sleep = async (ms: number): Promise<void> => await new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * The check-then-act pattern from the order find-or-create paths, reduced to
+ * its essence. The delay between check and insert widens the race window so
+ * the duplicate insert is deterministic instead of timing-dependent.
+ */
+async function findOrCreate (
+  connection: Connection,
+  integrationId: string,
+  externalId: string,
+  delayMs: number,
+): Promise<void> {
+  const rows = await connection.query(
+    'SELECT id FROM `order_like` WHERE `integrationId` = ? AND `externalId` = ?',
+    [integrationId, externalId],
+  )
+  if (rows.length > 0) {
+    return
+  }
+  await sleep(delayMs)
+  await connection.query(
+    'INSERT INTO `order_like` (`integrationId`, `externalId`) VALUES (?, ?)',
+    [integrationId, externalId],
+  )
+}
+
+async function countOrders (
+  connection: Connection,
+  integrationId: string,
+  externalId: string,
+): Promise<number> {
+  const [{ c }] = await connection.query(
+    'SELECT COUNT(*) AS c FROM `order_like` WHERE `integrationId` = ? AND `externalId` = ?',
+    [integrationId, externalId],
+  )
+  return Number(c)
+}
+
+describe('NamedLockService against real MySQL (issue #320)', () => {
+  let adminConnection: Connection | null = null
+  // Two separate connections/pools simulate two dmi-api replicas sharing MySQL.
+  let replicaA: Connection | null = null
+  let replicaB: Connection | null = null
+  let lockA: NamedLockService
+  let lockB: NamedLockService
+  let canRun = false
+
+  beforeAll(async () => {
+    try {
+      adminConnection = await createConnection({
+        ...baseConfig,
+        name: 'named-lock-admin',
+      })
+      await adminConnection.query(`DROP DATABASE IF EXISTS \`${TEST_DB}\``)
+      await adminConnection.query(`CREATE DATABASE \`${TEST_DB}\``)
+
+      replicaA = await createConnection({
+        ...baseConfig,
+        database: TEST_DB,
+        name: 'named-lock-replica-a',
+      })
+      replicaB = await createConnection({
+        ...baseConfig,
+        database: TEST_DB,
+        name: 'named-lock-replica-b',
+      })
+      await replicaA.query(`
+        CREATE TABLE \`order_like\` (
+          \`id\` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+          \`integrationId\` VARCHAR(36) NOT NULL,
+          \`externalId\` VARCHAR(255) NOT NULL
+        )
+      `)
+
+      lockA = new NamedLockService(replicaA as any)
+      lockB = new NamedLockService(replicaB as any)
+      canRun = true
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[named-lock.e2e] MySQL not reachable, skipping. Reason: ${(err as Error).message}`,
+      )
+    }
+  }, 60_000)
+
+  afterAll(async () => {
+    if (replicaA?.isConnected) {
+      await replicaA.close()
+    }
+    if (replicaB?.isConnected) {
+      await replicaB.close()
+    }
+    if (adminConnection?.isConnected) {
+      if (canRun) {
+        await adminConnection.query(`DROP DATABASE IF EXISTS \`${TEST_DB}\``)
+      }
+      await adminConnection.close()
+    }
+  }, 60_000)
+
+  it(
+    'documents the bug: unserialized check-then-act from two replicas inserts duplicates',
+    async () => {
+      if (!canRun) {
+        return
+      }
+      const [connA, connB] = [replicaA!, replicaB!]
+
+      await Promise.all([
+        findOrCreate(connA, 'int-1', 'EXT-UNLOCKED', 100),
+        findOrCreate(connB, 'int-1', 'EXT-UNLOCKED', 100),
+      ])
+
+      expect(await countOrders(connA, 'int-1', 'EXT-UNLOCKED')).toBe(2)
+    },
+    30_000,
+  )
+
+  it(
+    'serializes find-or-create across replicas: only one order is inserted',
+    async () => {
+      if (!canRun) {
+        return
+      }
+      const [connA, connB] = [replicaA!, replicaB!]
+
+      const key = orderLockKey('int-1', 'EXT-LOCKED')
+      await Promise.all([
+        lockA.withLock(key, async () => await findOrCreate(connA, 'int-1', 'EXT-LOCKED', 100)),
+        lockB.withLock(key, async () => await findOrCreate(connB, 'int-1', 'EXT-LOCKED', 100)),
+      ])
+
+      expect(await countOrders(connA, 'int-1', 'EXT-LOCKED')).toBe(1)
+    },
+    30_000,
+  )
+
+  it(
+    'does not serialize different (integrationId, externalId) pairs against each other',
+    async () => {
+      if (!canRun) {
+        return
+      }
+
+      const start = Date.now()
+      await Promise.all([
+        lockA.withLock(orderLockKey('int-1', 'EXT-A'), async () => await sleep(500)),
+        lockB.withLock(orderLockKey('int-2', 'EXT-A'), async () => await sleep(500)),
+      ])
+
+      // Different keys must run concurrently (~500ms), not sequentially (~1000ms).
+      expect(Date.now() - start).toBeLessThan(900)
+    },
+    30_000,
+  )
+
+  it(
+    'degrades gracefully: proceeds without the lock after the wait timeout',
+    async () => {
+      if (!canRun) {
+        return
+      }
+
+      const [connA, connB] = [replicaA!, replicaB!]
+
+      const key = orderLockKey('int-1', 'EXT-STUCK')
+      // A stuck holder: acquires the lock and never releases it.
+      const stuckHolder = connA.createQueryRunner()
+      await stuckHolder.query('SELECT GET_LOCK(MD5(?), 1)', [key])
+
+      try {
+        const start = Date.now()
+        await lockB.withLock(key, async () => await findOrCreate(connB, 'int-1', 'EXT-STUCK', 0))
+
+        // Waited the full timeout (5s), then ran the critical section anyway.
+        expect(Date.now() - start).toBeGreaterThanOrEqual(4_900)
+        expect(await countOrders(connB, 'int-1', 'EXT-STUCK')).toBe(1)
+      } finally {
+        await stuckHolder.query('SELECT RELEASE_LOCK(MD5(?))', [key])
+        await stuckHolder.release()
+      }
+    },
+    30_000,
+  )
+})


### PR DESCRIPTION
Closes #320

## Problem

The order find-or-create paths are check-then-act: two events referencing the same external order processed concurrently (e.g. an `external_results` and an `external_orders` event emitted near-simultaneously by the engine's polls) can both pass the "not found" check and both insert, producing duplicate orders/reports and duplicate `ORDER_CREATED` webhooks. With multi-replica dmi-api (#292) the interleaving becomes true parallelism.

A DB unique index on `(integrationId, externalId)` is not an option: clinics legitimately reuse external IDs for orphan results, and the #307 reconciliation logic deliberately creates same-`externalId` orders for different episodes. The "same episode vs. new episode" decision must stay in application code.

## Changes

- **`NamedLockService`**: serializes critical sections across replicas with MySQL named locks (`GET_LOCK`/`RELEASE_LOCK`), keyed by `MD5('order:' + integrationId + ':' + externalId)`.
  - Acquire and release happen on the same dedicated query runner (releasing on a different pool connection is a silent no-op); on pod crash MySQL releases the lock when the connection dies.
  - 5s wait timeout, then logs a warning and proceeds without the lock — graceful degradation to today's behavior, never worse.
  - No-op on non-MySQL drivers (sqlite in tests).
- **Lock the three find-or-create sections**, re-checking existence under the lock:
  - `OrdersService.handleExternalOrders` (non-existing orders): the loser of the race sees the winner's order and skips creation (no duplicate event).
  - `ReportsService.handleExternalResults` (external orders): the provider fetch (`getOrderFromProvider`, potentially seconds of HTTP) stays **outside** the lock; a concurrently-created order is reused for the report without emitting a duplicate `ORDER_CREATED`.
  - `ReportsService.handleExternalResults` (orphan results): the find + #307 window logic (`isMatchingOrder`/`isStaleOrphanMatch`) + insert run under the lock, so the loser sees the created order and the existing logic decides whether to reconcile into it or create a new order.
- **Scope `findOrdersByExternalIds` by `integrationId`** (mirroring the #307 fix to `findOneByExternalId`), so the lock protects a lookup that respects its key. Callers without integration context (event logging) keep the global lookup.

## Testing

- Unit tests for `NamedLockService` (acquire/release on the same runner, timeout degradation, release on error, non-MySQL bypass).
- Race-scenario tests for both services: creation is skipped/reused when the re-check under the lock finds the concurrently-created order.
- Tests for the integration scoping of `findOrdersByExternalIds`.
- E2E spec against real MySQL (`test/e2e/named-lock.e2e-spec.ts`) simulating two replicas: reproduces the unserialized duplicate insert, proves the lock serializes find-or-create to a single row, proves unrelated keys do not serialize each other, and proves graceful degradation after the lock wait timeout. Skips cleanly when MySQL is not running.
