### PR TITLE
Stop swallowing external_requests_v3 write errors

### DIFF
--- a/src/providers/services/providers.service.spec.ts
+++ b/src/providers/services/providers.service.spec.ts
@@ -262,6 +262,60 @@ describe('ProvidersService', () => {
       createSpy.mockRestore()
       findOneSpy.mockRestore()
     })
+    it('should log and retry without the body when a write error is reported (regression: MongoServerError)', async () => {
+      // mongoose 6 / driver 4 renamed server errors from MongoError to MongoServerError,
+      // which the old error.name check silently ignored, dropping the write with no trace.
+      const error = Object.assign(new Error('Request rate is large'), { name: 'MongoServerError', code: 16500 })
+      const bodies: any[] = []
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
+        .mockImplementationOnce((data: any, cb: any) => { bodies.push(data.body); cb(error); return undefined as any })
+        .mockImplementationOnce((data: any, cb: any) => { bodies.push(data.body); cb(null); return undefined as any })
+      const loggerSpy = jest.spyOn((service as any).logger, 'error').mockImplementation(() => {})
+
+      const data = {
+        headers: { 'Content-Type': 'application/json' },
+        body: { some: 'data' },
+        url: 'http://example.com',
+        method: 'POST',
+        provider: 'test-provider',
+        status: 200,
+        payload: undefined
+      }
+
+      await service.saveProviderRawData(data)
+
+      expect(createSpy).toHaveBeenCalledTimes(2)
+      expect(bodies[0]).toBeDefined() // first attempt keeps the body
+      expect(bodies[1]).toBeUndefined() // fallback drops the body
+      expect(loggerSpy).toHaveBeenCalledTimes(1)
+
+      createSpy.mockRestore()
+      loggerSpy.mockRestore()
+    })
+    it('should log again when the body-less fallback write also fails', async () => {
+      const error = Object.assign(new Error('boom'), { name: 'MongoServerError' })
+      const createSpy = jest.spyOn(providerExternalRequestsV3Model, 'create')
+        .mockImplementation((_data: any, cb: any) => { cb(error); return undefined as any })
+      const loggerSpy = jest.spyOn((service as any).logger, 'error').mockImplementation(() => {})
+
+      const data = {
+        headers: {},
+        body: { some: 'data' },
+        url: 'http://example.com',
+        method: 'POST',
+        provider: 'test-provider',
+        status: 200,
+        payload: undefined
+      }
+
+      await service.saveProviderRawData(data)
+
+      expect(createSpy).toHaveBeenCalledTimes(2)
+      expect(loggerSpy).toHaveBeenCalledTimes(2)
+
+      createSpy.mockRestore()
+      loggerSpy.mockRestore()
+    })
   })
   describe('buildExternalRequestPartitionKey', () => {
     it('should scope the key to provider, practice and UTC day', () => {

--- a/src/providers/services/providers.service.ts
+++ b/src/providers/services/providers.service.ts
@@ -430,16 +430,18 @@ export class ProvidersService implements OnModuleInit {
     }
 
     this.providerExternalRequestsV3Model.create(rawData, (error) => {
-      if (error != null && error.name === 'MongoError') {
-        this.logger.error(error.message)
-        this.logger.warn(`Could not save external request (${method} ${url}) to the database, saving without the body`)
+      // Any non-null error means the write failed. Do not filter by error.name:
+      // the mongoose 6 / driver 4 upgrade renamed server errors from 'MongoError'
+      // to 'MongoServerError', so the old check silently dropped every failed
+      // write (429 throttling, 413 oversized document, etc.) with no trace.
+      if (error != null) {
+        this.logger.error(`Could not save external request (${method} ${url}), saving without the body: ${error.message}`)
 
         // TODO(gb): implement a better fallback strategy than just removing the body
         delete rawData.body
         this.providerExternalRequestsV3Model.create(rawData, (error) => {
-          if (error != null && error.name === 'MongoError') {
-            this.logger.error(error.message)
-            this.logger.warn('Could not save external request (without the body) to database')
+          if (error != null) {
+            this.logger.error(`Could not save external request (${method} ${url}) without the body either: ${error.message}`)
           }
         })
       }


### PR DESCRIPTION
## Summary

Fixes defect #2 from #323: the `external_requests_v3` insert callback filtered on `error.name === 'MongoError'`, which never matches since the mongoose 6 / driver 4 upgrade renamed server errors to `MongoServerError`. As a result, failed writes (429 throttling, 413 oversized documents, etc.) were dropped with **no log, no warning, and the body-less fallback insert never ran** — the document was lost with zero trace. The ~220 throttled inserts during the 2026-07-09/10 PROD incident disappeared exactly this way.

## Changes

- `saveProviderRawData`: treat any non-null callback error as a failed write (no filtering by name). Log it and run the body-less fallback insert.
- Raise the fallback-failure log from `warn` to `error`, since that path means silent data loss.
- Add two regression tests: one drives a `MongoServerError` through the callback and asserts the error is logged and the write is retried without the body; the other asserts both failures are logged when the body-less fallback also fails.

## Not included (defect #1)

The RU/s throughput provisioning is intentionally **out of scope** here — it's a Cosmos/infra concern and provisioning is already resolved in PROD. See the discussion on #323 for the two proposed directions (IaC ownership vs. code stopgap); the team will decide whether to spin a separate DevOps issue.

Refs #323
