### PR TITLE
Make integration restart pass usable for Redis cutovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ lerna-debug.log*
 .yalc
 yalc.lock
 .secret-key
+__pycache__/

--- a/docs/redis-cutover-job-reregistration.md
+++ b/docs/redis-cutover-job-reregistration.md
@@ -1,0 +1,133 @@
+# Re-registering polling jobs after a Redis cutover
+
+## Why this exists
+
+Repeatable polling jobs live **only in Redis** and nothing re-creates them.
+
+- `QueueManager.onModuleInit` (dmi-engine) only adjusts intervals on jobs that already exist.
+- Jobs are registered solely by dmi-api's `doStart()` publishing MQTT `integration/create`.
+
+Neither service reconciles at startup, so **restarting pods does not help**. After a cutover to a
+new Redis instance — or any eviction, flush or data loss — integrations stay `RUNNING` in the
+database while polling is silently dead, and the pods report healthy throughout. This was
+confirmed end-to-end in DEV on 2026-07-23.
+
+`ensure-integration-status` is the reconciliation pass: it restarts integrations so the engines
+re-register their jobs. It is idempotent and safe to re-run — restarting an integration whose jobs
+already exist simply replaces them.
+
+Tracked in [nominal-systems/dmi-api#328](https://github.com/nominal-systems/dmi-api/issues/328).
+
+## What it does
+
+For each selected integration it calls the same `restart()` used by
+`POST /admin/integrations/:id/restart`: `integration/remove` followed by `integration/create` over
+ActiveMQ. Note `/start` cannot be used — it short-circuits with "already running" because the
+database still says `RUNNING`.
+
+Defaults:
+
+- **`RUNNING` integrations only.** Restarting a `STOPPED` integration only issues a pointless
+  `integration/remove`; it is never started.
+- **Concurrency 5**, 3 attempts per integration with exponential backoff from 1s.
+- **Failures do not abort the run.** Every failure is collected and reported at the end, and the
+  process exits non-zero.
+
+If a start fails after the stop succeeded, the previous status is restored in the database. A
+`RUNNING` row whose jobs are missing is exactly what this pass repairs, so it stays visible to a
+re-run; leaving it `STOPPED` would make it invisible forever.
+
+Each engine request is bounded by `ENGINE_RESPONSE_TIMEOUT` (default 90s). Lower it for large
+batches where some engines are expected to be unreachable — the worst case is
+`attempts × 90s` per integration otherwise.
+
+## Usage
+
+```
+npm run ensure-integration-status -- [options]
+```
+
+| Option | Default | |
+| --- | --- | --- |
+| `--status=RUNNING[,STOPPED]` | `RUNNING` | Statuses to restart |
+| `--provider=idexx[,zoetis]` | all | Restrict to provider ids |
+| `--integration-id=<id>[,...]` | all | Restrict to integration ids |
+| `--concurrency=<n>` | `5` | Restarted in parallel |
+| `--attempts=<n>` | `3` | Attempts per integration |
+| `--backoff=<ms>` | `1000` | Base delay, doubled each retry |
+| `--dry-run` | off | List what would be restarted, change nothing |
+
+It needs database and ActiveMQ access, not the admin API — so it runs in-cluster and is unaffected
+by the Okta admin auth in DEV.
+
+### Running it as a Job
+
+Reuse the deployed image and its environment. `<release>` is the running dmi-api deployment.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ensure-integration-status
+  namespace: devv2
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: ensure-integration-status
+          image: <same image as the dmi-api deployment>
+          command: ['npm', 'run', 'ensure-integration-status', '--']
+          args: ['--dry-run']
+          envFrom:
+            - configMapRef:
+                name: <dmi-api configmap>
+            - secretRef:
+                name: <dmi-api secret>
+```
+
+```bash
+kubectl -n devv2 logs -f job/ensure-integration-status
+```
+
+Drop `--dry-run` for the real pass. Delete the Job before re-applying it.
+
+## Cutover procedure
+
+1. **Before** — record the baseline:
+   ```bash
+   python3 scripts/verify-repeat-keys.py --host <old-instance>.redis.cache.windows.net
+   ```
+   Note the total. Also count `RUNNING` integrations: expect **2 jobs each** (orders + results).
+2. Repoint the deployments at the new instance and roll them.
+3. **Dry run** the pass and check the count matches what you expect to restart.
+4. Run it for real. It exits non-zero and lists every integration it could not restart.
+5. **After** — verify the jobs actually landed:
+   ```bash
+   python3 scripts/verify-repeat-keys.py --host <new-instance>.redis.cache.windows.net --expect <2 × RUNNING>
+   ```
+6. Re-run the pass for any failures. It is idempotent.
+
+Use `--provider=` to move one engine at a time; each engine has its own queue prefix
+(`{}` for core dmi-engine and wisdom-panel, `{bull:idexx}`, `{bull:antech}`, and zoetis is not
+hash-tagged — see
+[dmi-engine-zoetis-integration#36](https://github.com/nominal-systems/dmi-engine-zoetis-integration/issues/36)).
+
+## Verifying what is registered
+
+`scripts/verify-repeat-keys.py` counts Bull's repeat registries (the `<prefix>:<queue>:repeat`
+ZSETs), grouped by prefix. It scans rather than assuming a layout, so it works across engines with
+different prefixes.
+
+```bash
+REDIS_PASSWORD=... python3 scripts/verify-repeat-keys.py \
+  --host voyager-dev-dmi-scus-rc.redis.cache.windows.net --expect 10
+```
+
+It also reports keys still sitting under the legacy non-hash-tagged `bull:` prefix — debris from
+the earlier prefix migration, which must be 0 on the new instances.
+
+Needs the `redis` package and network access to the instance: run it from the dmi-monitor
+container, or via `kubectl run` inside the cluster when the instance is behind a private endpoint.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,9 @@
+# Scripts
+
+- `mongo-shard-migrate.js` — copies documents into sharded Cosmos collections (below).
+- `verify-repeat-keys.py` — counts Bull repeatable-job registrations in a Redis instance, used to
+  verify a Redis cutover. See [docs/redis-cutover-job-reregistration.md](../docs/redis-cutover-job-reregistration.md).
+
 # Migration Script: mongo-shard-migrate.js
 
 This script copies documents from existing (unsharded) collections into new, sharded collections in Cosmos DB (Mongo API), preserving `_id` and running in batches.

--- a/scripts/verify-repeat-keys.py
+++ b/scripts/verify-repeat-keys.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Count Bull repeatable-job registrations in a Redis instance.
+
+Repeatable polling jobs live only in Redis. After a cutover (or any eviction/flush) the
+integrations stay RUNNING in the database while their jobs are gone, and nothing reports it --
+the pods look healthy. This script is the check: it counts what is actually registered, so a
+restart pass can be verified instead of assumed.
+
+Bull keeps the repeat registry in a ZSET at `<prefix>:<queue>:repeat`, one member per repeatable
+job. Prefixes differ per engine (`{}`, `{bull:idexx}`, `{bull:antech}`, and zoetis is not
+hash-tagged), so this scans for every `*:repeat` ZSET rather than assuming a layout.
+
+Usage:
+  python3 verify-repeat-keys.py --host <name>.redis.cache.windows.net [--expect 10]
+
+  REDIS_PASSWORD=... python3 verify-repeat-keys.py --host ... --port 6380
+
+Runs anywhere with the `redis` package and network access to the instance -- e.g. the
+dmi-monitor container, or `kubectl run` inside the cluster when the instance is behind a
+private endpoint.
+"""
+
+import argparse
+import os
+import sys
+from collections import defaultdict
+
+try:
+    import redis
+except ImportError:  # pragma: no cover
+    sys.exit("The 'redis' package is required: pip install redis")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--host", required=True, help="Redis hostname")
+    parser.add_argument("--port", type=int, default=6380, help="Redis port (default: 6380, TLS)")
+    parser.add_argument("--password", default=os.environ.get("REDIS_PASSWORD"),
+                        help="Access key (default: $REDIS_PASSWORD)")
+    parser.add_argument("--no-tls", action="store_true", help="Connect without TLS")
+    parser.add_argument("--db", type=int, default=0, help="Database index (default: 0)")
+    parser.add_argument("--match", default="*repeat*",
+                        help="SCAN pattern (default: *repeat*)")
+    parser.add_argument("--expect", type=int, default=None,
+                        help="Expected total repeatable jobs; exit 1 if the total differs")
+    parser.add_argument("--legacy-prefix", default="bull:",
+                        help="Report keys under this non-hash-tagged prefix separately "
+                             "(default: bull:) -- debris from the earlier prefix migration")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    client = redis.Redis(
+        host=args.host,
+        port=args.port,
+        password=args.password,
+        ssl=not args.no_tls,
+        db=args.db,
+        decode_responses=True,
+        socket_timeout=15,
+    )
+
+    registries = {}
+    legacy_keys = 0
+    scanned = 0
+
+    for key in client.scan_iter(match=args.match, count=1000):
+        scanned += 1
+        if key.startswith(args.legacy_prefix):
+            legacy_keys += 1
+        if key.endswith(":repeat") and client.type(key) == "zset":
+            registries[key] = client.zcard(key)
+
+    if not registries:
+        print(f"No repeatable-job registries found (scanned {scanned} key(s) matching "
+              f"{args.match!r})")
+
+    by_prefix = defaultdict(list)
+    for key, count in registries.items():
+        # `<prefix>:<queue>:repeat` -- everything before the queue name is the prefix
+        parts = key.rsplit(":", 2)
+        prefix = parts[0] if len(parts) == 3 else key
+        by_prefix[prefix].append((key, count))
+
+    total = 0
+    for prefix in sorted(by_prefix):
+        entries = sorted(by_prefix[prefix])
+        subtotal = sum(count for _, count in entries)
+        total += subtotal
+        print(f"\n{prefix}  ({subtotal} job(s) across {len(entries)} queue(s))")
+        for key, count in entries:
+            print(f"  {count:>6}  {key}")
+
+    print(f"\nTotal repeatable jobs: {total}")
+    if legacy_keys:
+        print(f"Keys under legacy prefix {args.legacy_prefix!r}: {legacy_keys} "
+              f"(expected 0 after cutover validation)")
+
+    if args.expect is not None and total != args.expect:
+        print(f"\nFAIL: expected {args.expect} repeatable job(s), found {total}")
+        return 1
+
+    if args.expect is not None:
+        print(f"OK: matches the expected {args.expect}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ensure-integration-status.ts
+++ b/src/ensure-integration-status.ts
@@ -4,29 +4,169 @@ import { loadEnv } from './config/load-env'
 import { Logger } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
-import { IntegrationsService } from './integrations/integrations.service'
+import { EnsureStatusOptions, IntegrationsService } from './integrations/integrations.service'
+import { IntegrationStatus } from './integrations/constants/integration-status.enum'
+
+const USAGE = `
+Restart integrations so the engines re-register their repeatable polling jobs.
+
+Repeatable jobs live only in Redis and nothing re-creates them, so after a Redis cutover,
+eviction or flush the integrations stay RUNNING in the database with polling silently dead.
+This pass repairs that. It is idempotent and safe to re-run.
+
+Usage: npm run ensure-integration-status -- [options]
+
+Options:
+  --status=RUNNING[,STOPPED]   Statuses to restart (default: RUNNING)
+  --provider=idexx[,zoetis]    Restrict to these provider ids (default: all)
+  --integration-id=<id>[,...]  Restrict to these integration ids (default: all)
+  --concurrency=<n>            Integrations restarted in parallel (default: 5)
+  --attempts=<n>               Attempts per integration (default: 3)
+  --backoff=<ms>               Base delay between attempts, doubled each retry (default: 1000)
+  --dry-run                    List what would be restarted, change nothing
+  --help                       Show this message
+
+Exits non-zero if any integration could not be restarted.
+
+Note: each engine request is bounded by ENGINE_RESPONSE_TIMEOUT (default 90s). Lower it when
+restarting a large batch where some engines are expected to be unreachable.
+`
 
 const loaded = loadEnv()
-Logger.log(`Loaded environment configuration from ${loaded.join(', ')}`)
 
-async function ensureIntegrationStatus (): Promise<void> {
+class UsageError extends Error {}
+
+function parseList (value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+function parseNumber (name: string, value: string): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new UsageError(`Invalid value for --${name}: ${value}`)
+  }
+  return parsed
+}
+
+function parseStatuses (value: string): IntegrationStatus[] {
+  return parseList(value).map((status) => {
+    const parsed = IntegrationStatus[status.toUpperCase() as keyof typeof IntegrationStatus]
+    if (parsed === undefined) {
+      throw new UsageError(
+        `Invalid value for --status: ${status}. Expected one of ${Object.keys(IntegrationStatus).join(', ')}`
+      )
+    }
+    return parsed
+  })
+}
+
+export function parseArgs (argv: string[]): EnsureStatusOptions | undefined {
+  const options: EnsureStatusOptions = {}
+
+  for (const arg of argv) {
+    const [flag, value] = arg.split(/=(.*)/s)
+
+    if (flag === '--help' || flag === '-h') {
+      return undefined
+    }
+
+    if (flag === '--dry-run') {
+      options.dryRun = true
+      continue
+    }
+
+    if (value === undefined) {
+      throw new UsageError(`Unknown or incomplete argument: ${arg}`)
+    }
+
+    switch (flag) {
+      case '--status':
+        options.statuses = parseStatuses(value)
+        break
+      case '--provider':
+        options.providerIds = parseList(value)
+        break
+      case '--integration-id':
+        options.integrationIds = parseList(value)
+        break
+      case '--concurrency':
+        options.concurrency = parseNumber('concurrency', value)
+        break
+      case '--attempts':
+        options.attempts = parseNumber('attempts', value)
+        break
+      case '--backoff':
+        options.backoffMs = parseNumber('backoff', value)
+        break
+      default:
+        throw new UsageError(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+async function ensureIntegrationStatus (options: EnsureStatusOptions): Promise<number> {
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ['log', 'warn', 'error']
   })
   try {
-    await app.get(IntegrationsService).ensureStatusAll()
-    Logger.log('Finished ensuring integration status')
+    const summary = await app.get(IntegrationsService).ensureStatusAll(options)
+
+    if (summary.failures.length > 0) {
+      Logger.error(
+        `Failed to restart ${summary.failures.length} of ${summary.total} integration(s):\n` +
+          summary.failures
+            .map((failure) => `  ${failure.integrationId} (${failure.providerId}): ${failure.error}`)
+            .join('\n')
+      )
+      return 1
+    }
+
+    Logger.log(
+      summary.dryRun
+        ? `Dry run: ${summary.total} integration(s) would be restarted`
+        : `Finished ensuring integration status: ${summary.restarted} of ${summary.total} restarted`
+    )
+    return 0
   } finally {
     await app.close()
   }
 }
 
-/* eslint-disable @typescript-eslint/no-floating-promises */
-ensureIntegrationStatus()
-  .then(() => { process.exit(0) })
-  .catch((err) => {
-    Logger.error(
-      `Failed to ensure integration status: ${err instanceof Error ? err.message : err}`,
-      err instanceof Error ? err.stack : undefined)
-    process.exit(1)
-  })
+/* istanbul ignore next */
+function main (): void {
+  let options: EnsureStatusOptions | undefined
+  try {
+    options = parseArgs(process.argv.slice(2))
+  } catch (err) {
+    Logger.error(err instanceof Error ? err.message : String(err))
+    console.log(USAGE)
+    process.exit(2)
+  }
+
+  if (options === undefined) {
+    console.log(USAGE)
+    process.exit(0)
+  }
+
+  Logger.log(`Loaded environment configuration from ${loaded.join(', ')}`)
+
+  /* eslint-disable @typescript-eslint/no-floating-promises */
+  ensureIntegrationStatus(options)
+    .then((exitCode) => { process.exit(exitCode) })
+    .catch((err) => {
+      Logger.error(
+        `Failed to ensure integration status: ${err instanceof Error ? err.message : err}`,
+        err instanceof Error ? err.stack : undefined)
+      process.exit(1)
+    })
+}
+
+/* istanbul ignore next */
+if (require.main === module) {
+  main()
+}

--- a/src/integrations/integrations.service.spec.ts
+++ b/src/integrations/integrations.service.spec.ts
@@ -25,6 +25,7 @@ describe('IntegrationsService', () => {
     }),
   }
   const integrationRepositoryMock = {
+    find: jest.fn(),
     findOne: jest.fn((obj) => obj),
     softDelete: jest.fn(),
     update: jest.fn(),
@@ -227,6 +228,167 @@ describe('IntegrationsService', () => {
       })
 
       expect(clientProxyMock.emit).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('restart()', () => {
+    const runningIntegration = {
+      id: 'integration-id',
+      status: IntegrationStatus.RUNNING,
+      providerConfiguration: {
+        id: 'provider-configuration-id',
+        providerId: 'idexx',
+        configurationOptions: {},
+      },
+      integrationOptions: {},
+    } as any
+
+    const resolves = (): any => ({ toPromise: async () => ({}) })
+    const rejects = (): any => ({
+      toPromise: async () => {
+        throw new Error('engine unreachable')
+      },
+    })
+
+    beforeEach(() => {
+      integrationRepositoryMock.update.mockClear()
+      clientProxyMock.send.mockReset()
+    })
+
+    it('should stop and start a RUNNING integration', async () => {
+      clientProxyMock.send.mockImplementation(resolves)
+
+      const response = await integrationsService.restart({ ...runningIntegration })
+
+      expect(response).toBeUndefined()
+      expect(clientProxyMock.send).toHaveBeenCalledTimes(2)
+      expect(integrationRepositoryMock.update).toHaveBeenLastCalledWith('integration-id', {
+        status: IntegrationStatus.RUNNING,
+      })
+    })
+
+    it('should not start an integration that was not RUNNING', async () => {
+      clientProxyMock.send.mockImplementation(resolves)
+
+      const response = await integrationsService.restart({
+        ...runningIntegration,
+        status: IntegrationStatus.STOPPED,
+      })
+
+      expect(response).toBeUndefined()
+      expect(clientProxyMock.send).toHaveBeenCalledTimes(1)
+    })
+
+    it('should restore the previous status when starting fails, so a re-run retries it', async () => {
+      clientProxyMock.send.mockImplementationOnce(resolves).mockImplementationOnce(rejects)
+
+      const response = await integrationsService.restart({ ...runningIntegration })
+
+      expect(response?.message).toContain('Error starting integration')
+      // doStop() persisted STOPPED, the failed start must not leave it there
+      expect(integrationRepositoryMock.update).toHaveBeenNthCalledWith(1, 'integration-id', {
+        status: IntegrationStatus.STOPPED,
+      })
+      expect(integrationRepositoryMock.update).toHaveBeenLastCalledWith('integration-id', {
+        status: IntegrationStatus.RUNNING,
+      })
+    })
+
+    it('should return the stop error without starting', async () => {
+      clientProxyMock.send.mockImplementation(rejects)
+
+      const response = await integrationsService.restart({ ...runningIntegration })
+
+      expect(response?.message).toContain('Error stopping integration')
+      expect(clientProxyMock.send).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('ensureStatusAll()', () => {
+    const integrationOf = (id: string, providerId: string, status = IntegrationStatus.RUNNING): any => ({
+      id,
+      status,
+      providerConfiguration: { id: `${id}-config`, providerId, configurationOptions: {} },
+      integrationOptions: {},
+    })
+
+    beforeEach(() => {
+      integrationRepositoryMock.find.mockReset()
+      integrationRepositoryMock.update.mockClear()
+      clientProxyMock.send.mockReset()
+      clientProxyMock.send.mockImplementation(() => ({ toPromise: async () => ({}) }))
+    })
+
+    it('should only restart RUNNING integrations by default', async () => {
+      integrationRepositoryMock.find.mockResolvedValue([integrationOf('a', 'idexx')])
+
+      const summary = await integrationsService.ensureStatusAll()
+
+      expect(integrationRepositoryMock.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: expect.objectContaining({ _value: [IntegrationStatus.RUNNING] }) },
+        }),
+      )
+      expect(summary).toEqual({ total: 1, restarted: 1, failures: [], dryRun: false })
+    })
+
+    it('should restrict to the requested providers and integrations', async () => {
+      integrationRepositoryMock.find.mockResolvedValue([
+        integrationOf('a', 'idexx'),
+        integrationOf('b', 'zoetis'),
+        integrationOf('c', 'idexx'),
+      ])
+
+      const summary = await integrationsService.ensureStatusAll({
+        providerIds: ['idexx'],
+        integrationIds: ['c'],
+      })
+
+      expect(summary.total).toBe(1)
+      expect(summary.restarted).toBe(1)
+      expect(clientProxyMock.send).toHaveBeenCalledTimes(2)
+    })
+
+    it('should change nothing on a dry run', async () => {
+      integrationRepositoryMock.find.mockResolvedValue([
+        integrationOf('a', 'idexx'),
+        integrationOf('b', 'zoetis'),
+      ])
+
+      const summary = await integrationsService.ensureStatusAll({ dryRun: true })
+
+      expect(summary).toEqual({ total: 2, restarted: 0, failures: [], dryRun: true })
+      expect(clientProxyMock.send).not.toHaveBeenCalled()
+      expect(integrationRepositoryMock.update).not.toHaveBeenCalled()
+    })
+
+    it('should retry a failing integration and report it without stopping the run', async () => {
+      integrationRepositoryMock.find.mockResolvedValue([
+        integrationOf('a', 'idexx'),
+        integrationOf('b', 'zoetis'),
+      ])
+      clientProxyMock.send.mockImplementation((pattern: string) => ({
+        toPromise: async () => {
+          if (pattern.startsWith('zoetis')) {
+            throw new Error('engine unreachable')
+          }
+          return {}
+        },
+      }))
+
+      const summary = await integrationsService.ensureStatusAll({
+        concurrency: 1,
+        attempts: 2,
+        backoffMs: 0,
+      })
+
+      expect(summary.total).toBe(2)
+      expect(summary.restarted).toBe(1)
+      expect(summary.failures).toEqual([
+        { integrationId: 'b', providerId: 'zoetis', error: 'Error stopping integration b' },
+      ])
+      // 2 sends for the integration that worked, 1 per attempt for the one that did not
+      expect(clientProxyMock.send).toHaveBeenCalledTimes(4)
     })
   })
 })

--- a/src/integrations/integrations.service.ts
+++ b/src/integrations/integrations.service.ts
@@ -15,6 +15,37 @@ import { IntegrationTestResponse, Operation, Resource } from '@nominal-systems/d
 import { IntegrationStatus } from './constants/integration-status.enum'
 import { Provider } from '../providers/entities/provider.entity'
 
+const DEFAULT_RESTART_CONCURRENCY = 5
+const DEFAULT_RESTART_ATTEMPTS = 3
+const DEFAULT_RESTART_BACKOFF_MS = 1000
+
+export interface EnsureStatusOptions {
+  /** Statuses to restart. Defaults to RUNNING only. */
+  statuses?: IntegrationStatus[]
+  /** Restrict to these providers (e.g. `idexx`), by provider id. */
+  providerIds?: string[]
+  /** Restrict to these integration ids. */
+  integrationIds?: string[]
+  concurrency?: number
+  attempts?: number
+  backoffMs?: number
+  /** Log what would be restarted without touching the engines or the database. */
+  dryRun?: boolean
+}
+
+export interface EnsureStatusFailure {
+  integrationId: string
+  providerId: string
+  error: string
+}
+
+export interface EnsureStatusSummary {
+  total: number
+  restarted: number
+  failures: EnsureStatusFailure[]
+  dryRun: boolean
+}
+
 @Injectable()
 export class IntegrationsService {
   private readonly logger = new Logger(IntegrationsService.name)
@@ -123,15 +154,31 @@ export class IntegrationsService {
   }
 
   async restart(integration: Integration): Promise<Error | undefined> {
+    const previousStatus = integration.status
     const responseStop = await this.doStop(integration)
-    if (responseStop?.message === undefined && integration.status === IntegrationStatus.RUNNING) {
-      await this.doStart(
-        integration.id,
-        integration.providerConfiguration,
-        integration.integrationOptions,
-      )
-    } else if (responseStop?.message !== undefined) {
+    if (responseStop?.message !== undefined) {
       return responseStop
+    }
+
+    if (previousStatus !== IntegrationStatus.RUNNING) {
+      return
+    }
+
+    const responseStart = await this.doStart(
+      integration.id,
+      integration.providerConfiguration,
+      integration.integrationOptions,
+    )
+
+    if (responseStart?.message !== undefined) {
+      // doStop() already persisted STOPPED. Restore the previous status so a re-run picks the
+      // integration up again: a RUNNING row whose jobs are missing is exactly what a restart pass
+      // is meant to repair, whereas a STOPPED row would be skipped from here on.
+      await this.integrationsRepository.update(integration.id, { status: previousStatus })
+      this.logger.warn(
+        `Failed to start integration ${integration.id}, restored status to ${previousStatus}`,
+      )
+      return responseStart
     }
   }
 
@@ -155,34 +202,144 @@ export class IntegrationsService {
     await this.doDelete(integration)
   }
 
-  async ensureStatusAll(): Promise<void> {
-    const integrations = await this.findAll({
-      where: {
-        status: In([IntegrationStatus.RUNNING, IntegrationStatus.STOPPED]),
-      },
-      relations: ['providerConfiguration'],
-    })
+  /**
+   * Restarts integrations so the engines re-register their repeatable polling jobs.
+   *
+   * Repeatable jobs live only in Redis and nothing re-creates them, so any Redis data loss (a
+   * cutover to a new instance, an eviction, a flush) leaves the integrations RUNNING in the
+   * database with no polling happening. This is the reconciliation pass for that state: it is
+   * idempotent and safe to re-run, since restarting an integration whose jobs already exist just
+   * replaces them.
+   */
+  async ensureStatusAll(options: EnsureStatusOptions = {}): Promise<EnsureStatusSummary> {
+    const statuses = options.statuses ?? [IntegrationStatus.RUNNING]
+    const concurrency = Math.max(1, options.concurrency ?? DEFAULT_RESTART_CONCURRENCY)
+    const attempts = Math.max(1, options.attempts ?? DEFAULT_RESTART_ATTEMPTS)
+    const backoffMs = Math.max(0, options.backoffMs ?? DEFAULT_RESTART_BACKOFF_MS)
 
-    const integrationStatusCounts = integrations.reduce(
-      (counts, integration) => {
-        counts[integration.status]++
-        return counts
-      },
-      { RUNNING: 0, STOPPED: 0 },
+    const integrations = this.filterIntegrations(
+      await this.findAll({
+        where: { status: In(statuses) },
+        relations: ['providerConfiguration'],
+      }),
+      options,
+    )
+
+    const statusCounts = integrations.reduce<Record<string, number>>((counts, integration) => {
+      counts[integration.status] = (counts[integration.status] ?? 0) + 1
+      return counts
+    }, {})
+
+    this.logger.log(
+      `Found ${integrations.length} integration(s) to restart: ${
+        Object.entries(statusCounts)
+          .map(([status, count]) => `${count} ${status}`)
+          .join(', ') || 'none'
+      }`,
+    )
+
+    if (options.dryRun === true) {
+      for (const integration of integrations) {
+        this.logger.log(
+          `[dry-run] Would restart integration ${integration.id} (provider ${integration.providerConfiguration.providerId}, status ${integration.status})`,
+        )
+      }
+      return { total: integrations.length, restarted: 0, failures: [], dryRun: true }
+    }
+
+    const failures: EnsureStatusFailure[] = []
+    let restarted = 0
+    let cursor = 0
+
+    const worker = async (): Promise<void> => {
+      while (cursor < integrations.length) {
+        const integration = integrations[cursor++]
+        const error = await this.restartWithRetry(integration, attempts, backoffMs)
+        if (error === undefined) {
+          restarted++
+          this.logger.log(
+            `Successfully restarted integration ${integration.id} (${
+              restarted + failures.length
+            }/${integrations.length})`,
+          )
+        } else {
+          failures.push({
+            integrationId: integration.id,
+            providerId: integration.providerConfiguration.providerId,
+            error: error.message,
+          })
+          this.logger.error(
+            `Error restarting integration ${integration.id}: ${error.message} (${
+              restarted + failures.length
+            }/${integrations.length})`,
+          )
+        }
+      }
+    }
+
+    await Promise.all(
+      Array.from({ length: Math.min(concurrency, integrations.length) }, async () => await worker()),
     )
 
     this.logger.log(
-      `Found: ${integrationStatusCounts.RUNNING} integrations RUNNING, ${integrationStatusCounts.STOPPED} integrations STOPPED`,
+      `Finished restarting integrations: ${restarted} succeeded, ${failures.length} failed`,
     )
 
-    for (const integration of integrations) {
-      const response = await this.restart(integration)
-      if (response?.message === undefined) {
-        this.logger.log(`Successfully restarted integration ${integration.id}`)
-      } else {
-        this.logger.error(`Error restarting integration ${integration.id}`)
+    return { total: integrations.length, restarted, failures, dryRun: false }
+  }
+
+  private filterIntegrations(
+    integrations: Integration[],
+    options: EnsureStatusOptions,
+  ): Integration[] {
+    const { providerIds, integrationIds } = options
+    return integrations.filter((integration) => {
+      if (
+        providerIds !== undefined &&
+        providerIds.length > 0 &&
+        !providerIds.includes(integration.providerConfiguration.providerId)
+      ) {
+        return false
+      }
+      if (
+        integrationIds !== undefined &&
+        integrationIds.length > 0 &&
+        !integrationIds.includes(integration.id)
+      ) {
+        return false
+      }
+      return true
+    })
+  }
+
+  private async restartWithRetry(
+    integration: Integration,
+    attempts: number,
+    backoffMs: number,
+  ): Promise<Error | undefined> {
+    let lastError: Error | undefined
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        lastError = await this.restart(integration)
+      } catch (e) {
+        lastError = e instanceof Error ? e : new Error(String(e))
+      }
+
+      if (lastError === undefined) {
+        return undefined
+      }
+
+      if (attempt < attempts) {
+        const delay = backoffMs * Math.pow(2, attempt - 1)
+        this.logger.warn(
+          `Attempt ${attempt}/${attempts} to restart integration ${integration.id} failed (${lastError.message}), retrying in ${delay}ms`,
+        )
+        await new Promise((resolve) => setTimeout(resolve, delay))
       }
     }
+
+    return lastError
   }
 
   async doDelete(integration: Integration): Promise<void> {


### PR DESCRIPTION
## Why

Repeatable polling jobs live **only in Redis** and nothing re-creates them:

- `QueueManager.onModuleInit` (dmi-engine) only adjusts intervals on jobs that already exist.
- Jobs are registered solely by dmi-api's `doStart()` publishing MQTT `integration/create`.

Neither service reconciles at startup, so **restarting pods does not help**. After a cutover to a new Redis instance — or any eviction or flush — integrations stay `RUNNING` in the database while polling is dead, and the pods report healthy throughout. Confirmed end-to-end in DEV on 2026-07-23.

`ensureStatusAll()` was the closest thing to a reconciliation pass, but it is referenced by no manifest, Job or pipeline, so it has never run in any environment — and it was not safe to run at scale.

## What changed

**`restart()` no longer strands integrations on failure.** `doStop()` persists `STOPPED` before `doStart()` runs. If the start failed, the row was left `STOPPED`, so a re-run would only stop it again and never start it — a partial failure permanently demoted integrations and re-running made it worse. It now restores the previous status, so a `RUNNING` row with missing jobs stays visible to the next pass. It also returns the start error, so `POST /admin/integrations/:id/restart` answers 400 on a failed start instead of a silent 201.

**`ensureStatusAll()` is now a real reconciliation pass:**

- `RUNNING` only by default. Restarting a `STOPPED` integration just issues a pointless `integration/remove` and never starts it — that was 60 of 65 integrations in DEV.
- Provider and integration-id filters, so engines can be moved one at a time.
- Bounded concurrency (default 5) instead of a strictly sequential loop. Each engine call is already bounded by `ENGINE_RESPONSE_TIMEOUT` (90s), so sequential worst case in prod was ~26h.
- 3 attempts per integration with exponential backoff; failures don't abort the run.
- Returns a `{total, restarted, failures, dryRun}` summary instead of `void`.

**`ensure-integration-status` gains a CLI:** `--status --provider --integration-id --concurrency --attempts --backoff --dry-run --help`. Exits 1 with a per-integration failure list, 2 on bad arguments. It needs database and ActiveMQ access rather than the admin API, so it runs in-cluster and is unaffected by Okta admin auth in DEV.

**`scripts/verify-repeat-keys.py`** counts Bull's repeat registries (`<prefix>:<queue>:repeat` ZSETs) grouped by prefix, with `--expect N` to fail on mismatch, and reports leftover legacy non-hash-tagged `bull:` keys for the "no DMI keys remain" validation. It scans rather than assuming a layout, so it handles `{}`, `{bull:idexx}`, `{bull:antech}` and untagged zoetis alike. No new npm dependency — it is Python, and runs in the dmi-monitor container.

**`docs/redis-cutover-job-reregistration.md`** covers the rationale, the options, a K8s Job manifest, and the before / dry-run / run / verify sequence.

## Testing

- 8 new unit tests: restore-on-failed-start, stop-error short circuit, `RUNNING`-only default, provider/integration filters, dry-run changes nothing, retry-then-report-without-aborting. Full suite passes (210).
- `verify-repeat-keys.py` exercised against a throwaway Redis seeded with mixed-prefix Bull keys: correct per-prefix grouping and totals, legacy debris reported separately, `--expect` mismatch exits 1.
- Not yet run against a real instance behind a private endpoint — that needs a `kubectl run` inside the namespace, which happens when the remaining DEV engines are repointed.

Refs #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)