### PR TITLE
Fix blank admin UI for visitors with a session cookie

### DIFF
--- a/src/common/guards/frontend-auth.guard.spec.ts
+++ b/src/common/guards/frontend-auth.guard.spec.ts
@@ -22,7 +22,7 @@ describe('FrontendAuthGuard', () => {
     guard = new FrontendAuthGuard(configService, jwtService)
   })
 
-  it('allows authenticated Okta requests with a profile username', () => {
+  it('allows authenticated Okta requests with a profile username', async () => {
     (configService.get as jest.Mock).mockImplementation((key: string) => {
       if (key === 'admin.authStrategy') return 'okta'
       if (key === 'baseUrl') return 'http://localhost:4000'
@@ -36,13 +36,13 @@ describe('FrontendAuthGuard', () => {
     }
     const response = { redirect: jest.fn() }
 
-    const result = guard.canActivate(createContext(request, response))
+    const result = await guard.canActivate(createContext(request, response))
 
     expect(result).toBe(true)
     expect(response.redirect).not.toHaveBeenCalled()
   })
 
-  it('redirects unauthenticated Okta requests to /auth/login', () => {
+  it('redirects unauthenticated Okta requests to /auth/login', async () => {
     (configService.get as jest.Mock).mockImplementation((key: string) => {
       if (key === 'admin.authStrategy') return 'okta'
       if (key === 'baseUrl') return 'http://localhost:4000'
@@ -55,7 +55,7 @@ describe('FrontendAuthGuard', () => {
     }
     const response = { redirect: jest.fn() }
 
-    const result = guard.canActivate(createContext(request, response))
+    const result = await guard.canActivate(createContext(request, response))
 
     expect(result).toBe(true)
     expect(response.redirect).toHaveBeenCalledWith(
@@ -64,7 +64,7 @@ describe('FrontendAuthGuard', () => {
     expect(request.__frontendAuthRedirected).toBe(true)
   })
 
-  it('does not treat missing Okta profile as authenticated', () => {
+  it('does not treat missing Okta profile as authenticated', async () => {
     (configService.get as jest.Mock).mockImplementation((key: string) => {
       if (key === 'admin.authStrategy') return 'okta'
       if (key === 'baseUrl') return 'http://localhost:4000'
@@ -78,14 +78,14 @@ describe('FrontendAuthGuard', () => {
     }
     const response = { redirect: jest.fn() }
 
-    const result = guard.canActivate(createContext(request, response))
+    const result = await guard.canActivate(createContext(request, response))
 
     expect(result).toBe(true)
     expect(response.redirect).toHaveBeenCalled()
     expect(request.__frontendAuthRedirected).toBe(true)
   })
 
-  it('redirects unauthenticated JWT requests to /ui/login', () => {
+  it('redirects unauthenticated JWT requests to /ui/login', async () => {
     (configService.get as jest.Mock).mockImplementation((key: string) => {
       if (key === 'admin.authStrategy') return 'jwt'
       if (key === 'baseUrl') return 'http://localhost:4000'
@@ -101,7 +101,7 @@ describe('FrontendAuthGuard', () => {
     }
     const response = { redirect: jest.fn() }
 
-    const result = guard.canActivate(createContext(request, response))
+    const result = await guard.canActivate(createContext(request, response))
 
     expect(result).toBe(true)
     expect(response.redirect).toHaveBeenCalledWith(

--- a/src/common/guards/frontend-auth.guard.ts
+++ b/src/common/guards/frontend-auth.guard.ts
@@ -11,7 +11,7 @@ export class FrontendAuthGuard implements CanActivate {
   ) {
   }
 
-  canActivate (context: ExecutionContext): boolean {
+  async canActivate (context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<FastifyRequest>()
     const response = context.switchToHttp().getResponse<FastifyReply>()
     const strategy = this.configService.get<string>('admin.authStrategy')
@@ -30,6 +30,7 @@ export class FrontendAuthGuard implements CanActivate {
       ;(request as any).__frontendAuthRedirected = true
       const redirectUrl = encodeURIComponent(`${baseUrl}${request.url}`)
       response.redirect(`${baseUrl}/auth/login?redirect=${redirectUrl}`)
+      await this.flush(response)
       return true
     }
 
@@ -45,10 +46,33 @@ export class FrontendAuthGuard implements CanActivate {
       (request as any).__frontendAuthRedirected = true
       const redirectUrl = encodeURIComponent(request.url)
       response.redirect(`${baseUrl}/ui/login?redirect=${redirectUrl}`)
+      await this.flush(response)
       return true
     }
 
     // Fallback: deny
     return false
+  }
+
+  /**
+   * Waits until the redirect response has fully flushed to the client.
+   *
+   * `reply.redirect()` only queues the response: fastify's onSend hooks run first, and since
+   * sessions moved to MongoDB the session-store save inside that hook takes a network round
+   * trip. If the guard returns while the redirect is still parked there, Nest proceeds and
+   * applies the route's default success status to the not-yet-flushed reply, silently
+   * overwriting the 302 with a 200. The client then receives an empty 200 (with the location
+   * header still attached, but never followed) — a blank page instead of the login flow.
+   *
+   * This never happened with the in-memory session store because the save completed
+   * synchronously, flushing the 302 before the guard returned. FastifyReply is thenable:
+   * awaiting it resolves once the response stream has ended, making the overwrite a no-op.
+   */
+  private async flush (response: FastifyReply): Promise<void> {
+    try {
+      await response
+    } catch {
+      // The client aborted mid-flush; the request is over either way.
+    }
   }
 }

--- a/test/e2e/frontend-redirect.e2e-spec.ts
+++ b/test/e2e/frontend-redirect.e2e-spec.ts
@@ -1,0 +1,156 @@
+import { Controller, Get, INestApplication, Res, UseGuards } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { JwtService } from '@nestjs/jwt'
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify'
+import { Test } from '@nestjs/testing'
+import { FastifyReply } from 'fastify'
+import fastifyCookie from '@fastify/cookie'
+import fastifySession from '@fastify/session'
+import { FrontendAuthGuard } from '../../src/common/guards/frontend-auth.guard'
+
+/**
+ * Regression test for the blank admin UI after sessions moved to MongoDB.
+ *
+ * FrontendAuthGuard sends a redirect and returns true, letting the route handler run and rely
+ * on `__frontendAuthRedirected` to skip the file send. But `reply.redirect()` only queues the
+ * response — fastify's onSend hooks run first, and with an asynchronous session store
+ * (connect-mongo) the save inside that hook takes a network round trip. While the 302 sat
+ * parked there, Nest applied the route's default success status to the not-yet-flushed reply,
+ * silently overwriting it to 200. The client got an empty 200 (location header attached but
+ * never followed): a blank page for any visitor carrying a session cookie, i.e. anyone who had
+ * started a login.
+ *
+ * The store here mimics connect-mongo's latency with a delayed in-memory store — the bug does
+ * not reproduce with a synchronous store, which is why it appeared only after the MongoDB
+ * migration.
+ */
+
+const STORE_LATENCY_MS = 25
+
+class SlowStore {
+  private readonly sessions = new Map<string, any>()
+
+  get (sid: string, cb: (err: Error | null, session?: any) => void): void {
+    const session = this.sessions.get(sid) ?? null
+    setTimeout(() => cb(null, session), STORE_LATENCY_MS)
+  }
+
+  set (sid: string, session: any, cb: (err?: Error | null) => void): void {
+    this.sessions.set(sid, session)
+    setTimeout(() => cb(null), STORE_LATENCY_MS)
+  }
+
+  destroy (sid: string, cb: (err?: Error | null) => void): void {
+    this.sessions.delete(sid)
+    setTimeout(() => cb(null), STORE_LATENCY_MS)
+  }
+
+  touch (_sid: string, _session: any, cb: (err?: Error | null) => void): void {
+    setTimeout(() => cb(null), STORE_LATENCY_MS)
+  }
+}
+
+/** Mimics FrontendController: guard first, handler skips the send after a redirect. */
+@UseGuards(FrontendAuthGuard)
+@Controller('ui')
+class TestFrontendController {
+  @Get()
+  async index (@Res() res: FastifyReply): Promise<void> {
+    if ((res.request as any)?.__frontendAuthRedirected || res.sent) return
+    await res.type('text/html').send('<html>INDEX</html>')
+  }
+}
+
+/** Mimics AuthController.login storing OIDC state in the session before redirecting. */
+@Controller('auth')
+class TestAuthController {
+  @Get('login')
+  async login (@Res({ passthrough: false }) res: FastifyReply): Promise<void> {
+    const req = res.request as any
+    req.session.redirectUrl = 'https://dmi.example.com/ui'
+    res.redirect('https://okta.example.com/authorize', 302)
+    await res
+  }
+}
+
+describe('Frontend redirect with an async session store (e2e)', () => {
+  let app: INestApplication
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TestFrontendController, TestAuthController],
+      providers: [
+        FrontendAuthGuard,
+        { provide: JwtService, useValue: { verify: jest.fn() } },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+              if (key === 'admin.authStrategy') return 'okta'
+              if (key === 'baseUrl') return 'https://dmi.example.com'
+              return defaultValue
+            }),
+          },
+        },
+      ],
+    }).compile()
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter())
+    const fastify = (app as NestFastifyApplication).getHttpAdapter().getInstance()
+    await fastify.register(fastifyCookie as any)
+    await fastify.register(fastifySession as any, {
+      secret: 'AAABBBCCCDDDEEEFFFGGGHHHIIIJJJKK',
+      store: new SlowStore() as any,
+      saveUninitialized: false,
+      cookie: { secure: false, maxAge: 30 * 60 * 1000 },
+    })
+    // fastify-passport is not registered here; simulate its request decoration
+    fastify.addHook('onRequest', async (req: any) => {
+      if (req.headers['x-test-authenticated'] === 'yes') {
+        req.isAuthenticated = () => true
+        req.user = { profile: { username: 'test.user@example.com' } }
+      }
+    })
+    await app.init()
+    await (app as NestFastifyApplication).getHttpAdapter().getInstance().ready()
+    await app.listen(0)
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  const baseUrl = async (): Promise<string> => await app.getUrl()
+
+  it('redirects a cookie-less request to the login flow', async () => {
+    const res = await fetch(`${await baseUrl()}/ui`, { redirect: 'manual' })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toContain('/auth/login?redirect=')
+  })
+
+  it('redirects a request that carries a session cookie (regression: blank page)', async () => {
+    // First hit /auth/login so the session stores OIDC-like state and a cookie is issued
+    const login = await fetch(`${await baseUrl()}/auth/login`, { redirect: 'manual' })
+    expect(login.status).toBe(302)
+    const sessionCookie = (login.headers.get('set-cookie') ?? '').split(';')[0]
+    expect(sessionCookie).toContain('sessionId=')
+
+    // A follow-up /ui visit with that session must still be a redirect, not an empty 200
+    const res = await fetch(`${await baseUrl()}/ui`, {
+      redirect: 'manual',
+      headers: { cookie: sessionCookie },
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toContain('/auth/login?redirect=')
+    expect(await res.text()).toBe('')
+  })
+
+  it('still serves the page for authenticated requests', async () => {
+    const res = await fetch(`${await baseUrl()}/ui`, {
+      redirect: 'manual',
+      headers: { 'x-test-authenticated': 'yes' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('INDEX')
+  })
+})


### PR DESCRIPTION
## Symptom

After 1.14.6 rolled out to DEV, https://devv2.dmi.voyager.marsvh.com/dmi/ui renders a **blank page** for anyone whose browser carries a `sessionId` cookie — which is anyone who has ever started a login. The response is an empty `200` that still carries the `location:` header of the redirect that should have happened:

```
HTTP/2 200
content-length: 0
location: https://devv2.dmi.voyager.marsvh.com/dmi/auth/login?redirect=...
set-cookie: sessionId=...
```

Cookie-less visitors get the correct 302 → Okta chain, which is why the smoke test right after deploy looked fine.

## Root cause

`FrontendAuthGuard` issues `response.redirect(...)` and returns `true`, relying on `__frontendAuthRedirected` for the handler to skip its send. That was safe while sessions lived in memory: the `@fastify/session` save inside fastify's **onSend hook** completed synchronously, so the 302 was fully flushed before the guard returned.

#321 moved sessions to MongoDB. The save is now a network round trip, so the redirect sits **queued but unflushed** when the guard returns — and Nest then applies the route's default success status to the reply, silently overwriting the 302 with a 200 (`kReplyHasStatusCode` is set, headers aren't). When the save completes, fastify writes the head with status 200, the untouched `location` header, and an empty body. One response, no error, nothing logged.

## Fix

The guard awaits the reply before returning (`FastifyReply` is thenable — it resolves when the response stream ends). The redirect is fully flushed by the time Nest touches the reply again, making the status write a no-op. Client-abort during the flush is swallowed; the request is over either way.

## Testing

- New e2e (`test/e2e/frontend-redirect.e2e-spec.ts`) boots the real guard on a Fastify Nest app with a session store that has simulated (~25ms) latency, mimicking connect-mongo against Cosmos:
  - cookie-less visit → 302 ✓ (passed before and after)
  - **visit with a session cookie → 302** — fails on the previous guard with exactly the DEV symptom (empty 200), passes with the fix
  - authenticated visit → 200 with page body ✓
- Existing guard spec updated for the async signature; full suite passes (210).
- Root cause confirmed against DEV: reproducible with `curl` (no-cookie 302 vs with-session-cookie 200-empty), same behavior straight against the pod bypassing ingress, both replicas.

Refs #321, #328 (found during the 1.14.6 DEV verification pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)