### PR TITLE
Persist observation-level units from provider results

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@nestjs/swagger": "^7.4.2",
     "@nestjs/terminus": "^10.2.3",
     "@nestjs/typeorm": "^10.0.2",
-    "@nominal-systems/dmi-engine-common": "^1.4.0",
+    "@nominal-systems/dmi-engine-common": "^1.6.0",
     "argon2": "^0.28.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/src/migrations/1785384915447-ObservationUnits.ts
+++ b/src/migrations/1785384915447-ObservationUnits.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ObservationUnits1785384915447 implements MigrationInterface {
+  name = 'ObservationUnits1785384915447'
+
+  public async up (queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `observation` ADD `units` varchar(255) NULL')
+  }
+
+  public async down (queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `observation` DROP COLUMN `units`')
+  }
+}

--- a/src/reports/entities/observation.entity.ts
+++ b/src/reports/entities/observation.entity.ts
@@ -37,6 +37,9 @@ export class Observation {
   })
   valueQuantity?: ValueQuantity
 
+  @Column({ nullable: true })
+  units?: string
+
   // TODO(gb): add media
 
   @Column({

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -229,6 +229,44 @@ describe('ReportsService', () => {
         ]
       })
     })
+    it('should persist observation-level units for non-numeric results', () => {
+      const testResult = new TestResult()
+      testResult.observations = []
+      const items = [
+        {
+          code: '51001',
+          name: 'ALP',
+          status: TestResultItemStatus.DONE,
+          valueString: '< 20',
+          units: 'U/l',
+          referenceRange: [
+            {
+              type: 'NORMAL',
+              text: '0-229',
+              low: 0,
+              high: 229
+            }
+          ]
+        }
+      ]
+      reportsService.updateTestResultObservations(testResult, items)
+      expect(testResult.observations).toHaveLength(1)
+      expect(testResult.observations[0]).toEqual({
+        code: '51001',
+        name: 'ALP',
+        status: TestResultItemStatus.DONE,
+        valueString: '< 20',
+        units: 'U/l',
+        referenceRange: [
+          {
+            type: 'NORMAL',
+            text: '0-229',
+            low: 0,
+            high: 229
+          }
+        ]
+      })
+    })
     it('should update 1 test result with 2 equal items', () => {
       const testResult = new TestResult()
       testResult.observations = []

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -521,6 +521,11 @@ export class ReportsService {
       observation.valueString = item.valueString
     }
 
+    // Units
+    if (item.units != null) {
+      observation.units = item.units
+    }
+
     // Reference Range
     if (item.referenceRange != null) {
       observation.referenceRange = item.referenceRange


### PR DESCRIPTION
## What

Persist the new observation-level `units` field delivered by provider integrations onto the `Observation` entity, so units survive for results that do not carry a numeric `valueQuantity`.

## Background

Part of nominal-systems/dmi-engine-antech-v6-integration#71. Units received from Antech were dropped for every non-numeric result (`< 20`, `****`, …) because the only place to store a unit was nested inside `valueQuantity.units`, and non-numeric results take the `valueString` branch. dmi-engine-common now exposes a top-level `units?: string` on `ProviderTestResultItem`; this PR gives it a home in dmi-api.

## Approach

- **Entity** (`Observation`): new nullable `units?: string` column.
- **Migration** (`ObservationUnits1785384915447`): additive `ALTER TABLE observation ADD units varchar(255) NULL`. No backfill — historical rows stay `null`.
- **Service** (`updateObservationValue`): assign `observation.units = item.units` when present. Independent of the `valueQuantity` / `valueString` if/else, so it applies to both numeric and non-numeric results. Absent at the source → stays `null` in the DB and serializes as `null` to the PIMS, consistent with how `valueQuantity` already appears.
- Bump `@nominal-systems/dmi-engine-common` to `^1.6.0`.

## Safety

Fully additive: nullable column, no backfill, assignment guarded by `item.units != null`. Existing observations and consumers are unaffected. `tsc` typecheck and `eslint` clean.

## Tests

`reports.service.spec.ts`: new case asserting a non-numeric comparator result (ALP `< 20`) persists `units: "U/l"` alongside `valueString`. Existing `updateTestResultObservations` cases (which send no `units`) remain green — the field is simply absent, confirming the additive behavior.

## Caveats

Depends on **dmi-engine-common#28** (`1.6.0`) being released. The migration must be applied on deploy (`npm run migration:run`).