### PR TITLE
Stop unauthenticated /auth/callback from crashing the process

### DIFF
--- a/src/common/auth/auth.controller.spec.ts
+++ b/src/common/auth/auth.controller.spec.ts
@@ -34,8 +34,37 @@ describe('AuthController', () => {
 
   let controller: AuthController
 
+  // A reply stub that behaves like fastify's: headers are staged before the response is
+  // written, and `send()`/`redirect()` count as committing a response. `sends` is what the
+  // regression tests assert on — the crash in #356 was two responses on one reply.
+  function createReply (): any {
+    const headers: Record<string, any> = {}
+    const reply: any = {
+      sends: 0,
+      sent: false,
+      raw: { headersSent: false },
+      status: jest.fn(),
+      header: jest.fn((key: string, value: any) => {
+        headers[key.toLowerCase()] = value
+        return reply
+      }),
+      getHeader: jest.fn((key: string) => headers[key.toLowerCase()]),
+      send: jest.fn(() => {
+        reply.sends++
+        return reply
+      }),
+      redirect: jest.fn((url: string) => {
+        headers.location = url
+        reply.sends++
+        return reply
+      }),
+    }
+    return reply
+  }
+
   beforeEach(() => {
     controller = new AuthController(configServiceMock, jwtServiceMock)
+    ;(fastifyPassport.authenticate as jest.Mock).mockReset()
   })
 
   describe('callback()', () => {
@@ -48,15 +77,10 @@ describe('AuthController', () => {
         idToken: 'id-token',
       }
       const req: any = {
-        query: {},
+        query: { code: 'okta-code' },
         session: { redirectUrl: 'https://dmi.example.com/dmi/ui/integrations' },
       }
-      const res: any = {
-        status: jest.fn(),
-        header: jest.fn(),
-        send: jest.fn(),
-        redirect: jest.fn(),
-      }
+      const res = createReply()
       ;(fastifyPassport.authenticate as jest.Mock).mockReturnValue(async () => {
         req.session.passport = oktaUser
         req.user = oktaUser
@@ -75,18 +99,71 @@ describe('AuthController', () => {
     })
 
     it('redirects to the login page when authentication leaves no user', async () => {
-      const req: any = { query: {}, session: {} }
-      const res: any = {
-        status: jest.fn(),
-        header: jest.fn(),
-        send: jest.fn(),
-        redirect: jest.fn(),
-      }
+      const req: any = { query: { code: 'okta-code' }, session: {} }
+      const res = createReply()
       ;(fastifyPassport.authenticate as jest.Mock).mockReturnValue(async () => {})
 
       await controller.callback(req, res)
 
       expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining('error=auth_failed'))
+      expect(res.sends).toBe(1)
+    })
+
+    // Regression: #356 — an unauthenticated GET /auth/callback with no code crashed the
+    // process with ERR_HTTP_HEADERS_SENT thrown out of @fastify/session's onSend hook.
+    it('answers a callback with no authorization code without invoking passport', async () => {
+      const req: any = { query: {}, session: {} }
+      const res = createReply()
+
+      await controller.callback(req, res)
+
+      expect(fastifyPassport.authenticate).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining('error=auth_failed'))
+      expect(res.sends).toBe(1)
+    })
+
+    it('sends nothing more once passport has committed its own redirect', async () => {
+      // This is what passport-openidconnect does when it decides to bounce the browser
+      // (failureRedirect, or a fresh authorization request): it redirects and resolves
+      // immediately, while the reply is still going through the async onSend chain.
+      const req: any = { query: { code: 'okta-code', state: 'garbage' }, session: {} }
+      const res = createReply()
+      ;(fastifyPassport.authenticate as jest.Mock).mockReturnValue(async () => {
+        res.redirect('https://okta.example.com/oauth2/v1/authorize?client_id=client-id')
+      })
+
+      await controller.callback(req, res)
+
+      expect(res.sends).toBe(1)
+      expect(res.redirect).not.toHaveBeenCalledWith(expect.stringContaining('error=auth_failed'))
+    })
+
+    it('does not send an error redirect on top of a reply that is already committed', async () => {
+      const req: any = { query: { code: 'okta-code' }, session: {} }
+      const res = createReply()
+      ;(fastifyPassport.authenticate as jest.Mock).mockReturnValue(async () => {
+        res.redirect('https://okta.example.com/oauth2/v1/authorize?client_id=client-id')
+        throw new Error('token exchange failed after the redirect went out')
+      })
+
+      await controller.callback(req, res)
+
+      expect(res.sends).toBe(1)
+    })
+  })
+
+  describe('login()', () => {
+    it('does not redirect again when authentication fails after committing a response', async () => {
+      const req: any = { query: {}, session: {} }
+      const res = createReply()
+      ;(fastifyPassport.authenticate as jest.Mock).mockReturnValue(async () => {
+        res.redirect('https://okta.example.com/oauth2/v1/authorize?client_id=client-id')
+        throw new Error('boom')
+      })
+
+      await controller.login(req, res)
+
+      expect(res.sends).toBe(1)
     })
   })
 })

--- a/src/common/auth/auth.controller.ts
+++ b/src/common/auth/auth.controller.ts
@@ -60,6 +60,22 @@ export class AuthController {
     return req.user?.profile ?? null
   }
 
+  /**
+   * True once something else has already committed a response on this reply.
+   *
+   * `reply.sent` alone is not enough: fastify-passport resolves its promise immediately
+   * after calling `reply.redirect()`, so control comes back here while that redirect is
+   * still travelling through the `onSend` hooks — and the MongoDB session store makes
+   * that leg async. `reply.sent` (which only tracks `raw.writableEnded`) and
+   * `raw.headersSent` are both still false in that window, so a second `send()` slips
+   * through and the two `writeHead` calls race. The loser throws ERR_HTTP_HEADERS_SENT
+   * from inside the hook chain, outside any try/catch, and takes the process down (#356).
+   * A staged `location` header is the synchronous signal that a redirect is on its way.
+   */
+  private replyAlreadyCommitted (res: FastifyReply): boolean {
+    return res.sent || res.raw.headersSent || res.getHeader('location') != null
+  }
+
   @Get('login')
   async login (@Req() req: FastifyRequest, @Res() res: FastifyReply): Promise<void> {
     // Capture the redirect query parameter and store it in the session.
@@ -85,6 +101,10 @@ export class AuthController {
       this.logger.error(error.message)
       this.logger.error(error.stack)
       this.logger.error('Full error:', error)
+      if (this.replyAlreadyCommitted(res)) {
+        this.logger.error('A response was already committed; not redirecting again')
+        return
+      }
       return await res.redirect(`${this.baseUrl}/ui/login?error=auth_failed`)
     }
   }
@@ -95,7 +115,7 @@ export class AuthController {
     this.logger.debug(`Query parameters: ${JSON.stringify(req.query)}`)
 
     // Check for Okta policy errors
-    const query = req.query as { error?: string; error_description?: string }
+    const query = req.query as { error?: string; error_description?: string; code?: string }
     if (query.error) {
       this.logger.error(`Okta authentication error: ${query.error}`)
       this.logger.error(`Error description: ${query.error_description}`)
@@ -104,6 +124,16 @@ export class AuthController {
           query.error_description || '',
         )}`,
       )
+    }
+
+    // Without an authorization code this is not a real Okta callback. Passport's OIDC
+    // strategy reads a code-less request as the *start* of an authorization flow and
+    // issues its own redirect to Okta, which then collides with the redirect this
+    // handler sends once it finds no user — an unauthenticated GET /auth/callback was
+    // enough to kill a replica (#356). Answer it here, before passport ever runs.
+    if (query.code == null || query.code === '') {
+      this.logger.warn('Callback received without an authorization code; redirecting to login')
+      return await res.redirect(`${this.baseUrl}/ui/login?error=auth_failed`)
     }
 
     try {
@@ -123,6 +153,13 @@ export class AuthController {
       // Complete the authentication
       this.logger.debug('Completing authentication...')
       await authenticate(req, res)
+
+      // `failureRedirect`, and any redirect the strategy issues itself, already answered
+      // the request. Anything we send now is a second response on the same reply (#356).
+      if (this.replyAlreadyCommitted(res)) {
+        this.logger.warn('Authentication committed its own response; not redirecting again')
+        return
+      }
 
       // At this point, the user should be authenticated and the session established
       if (req.user == null) {
@@ -151,6 +188,10 @@ export class AuthController {
       this.logger.error(error.message)
       this.logger.error(error.stack)
       this.logger.error('Full error:', error)
+      if (this.replyAlreadyCommitted(res)) {
+        this.logger.error('A response was already committed; not redirecting again')
+        return
+      }
       return await res.redirect(`${this.baseUrl}/ui/login?error=auth_failed`)
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,26 @@ import { registerMicroservices } from './common/plugins/microservices'
 const loaded = loadEnv()
 Logger.log(`Loaded environment configuration from ${loaded.join(', ')}`)
 
+// A response written twice surfaces as ERR_HTTP_HEADERS_SENT thrown from inside fastify's
+// async `onSend` chain, where no request-scoped try/catch can reach it. Losing the whole
+// replica to one malformed request is worse than dropping that request, so log and carry
+// on for that specific error; everything else keeps the previous fail-fast behaviour.
+function isSurvivable (err: unknown): boolean {
+  return (err as NodeJS.ErrnoException | undefined)?.code === 'ERR_HTTP_HEADERS_SENT'
+}
+
+function handleFatal (kind: string, err: unknown): void {
+  if (isSurvivable(err)) {
+    Logger.error(`Survivable ${kind}: ${(err as Error).message}`, (err as Error).stack)
+    return
+  }
+  Logger.error(`Fatal ${kind}:`, err instanceof Error ? err.stack : String(err))
+  process.exit(1)
+}
+
+process.on('uncaughtException', (err) => handleFatal('uncaughtException', err))
+process.on('unhandledRejection', (reason) => handleFatal('unhandledRejection', reason))
+
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
 async function bootstrap (): Promise<void> {


### PR DESCRIPTION
Fixes #356.

## The mechanism, corrected

The issue proposed guarding on `res.sent` / `res.raw.headersSent` before the second redirect. **That alone would not have fixed the reported case.** Tracing the actual path:

1. With no `code`, `passport-openidconnect` takes its *authorization-request* branch (`lib/strategy.js`, the `else` of `if (req.query && req.query.code)`) and calls `this.redirect(authorizeUrl)` — it reads a code-less request as the **start** of a login, not a callback.
2. `@fastify/passport`'s `strategy.redirect` does `void reply.redirect(url); resolve()` — it resolves **synchronously**, without awaiting the reply.
3. So the handler resumes while that redirect is still travelling through the `onSend` chain, which the MongoDB session store (#352) makes async. At that instant `reply.sent` (which only reads `raw.writableEnded`) and `raw.headersSent` are **both still false**.
4. `req.user` is null, the handler sends a second redirect, and the two `writeHead` calls race. The loser throws `ERR_HTTP_HEADERS_SENT` from inside the hook chain — outside any try/catch — and node exits 1.

This also supports the issue's hypothesis that the Mongo session store is what made the long-standing double-send *fatal*: it is the async `onSend` leg that opens the race window.

## The fix

**1. Reject code-less callbacks before passport runs** (`auth.controller.ts`). This is the root cause of the reported case — passport should never be handed a request it will interpret as a fresh authorization flow. `/auth/callback` is only ever Okta's `redirect_uri`; nothing else in the repo links to it, so there is no legitimate code-less caller to break.

**2. `replyAlreadyCommitted()`** — `res.sent || res.raw.headersSent || res.getHeader('location') != null`. The staged `location` header is the synchronous signal that catches the in-flight window the other two miss. Applied after `await authenticate()` and in the `catch` blocks of both `callback()` and `login()`, per the audit the issue asked for.

**3. Process-level backstop** (`main.ts`) — `uncaughtException` / `unhandledRejection` log and survive `ERR_HTTP_HEADERS_SENT`; every other error keeps the existing `exit(1)`. A double-send anywhere now degrades to a logged error instead of a dead replica.

## Tests

Regression specs use a reply stub that counts commits, so each asserts **exactly one response** per request:

- no `code` → one redirect, and passport is never invoked
- strategy issues its own redirect, `req.user` null → no second redirect
- a throw *after* a redirect already went out → catch block does not redirect again
- same for `login()`

The two pre-existing `callback()` specs now pass a `code` so they still exercise the post-authenticate path.

Full suite: 216 passed / 24 suites. `tsc --noEmit` and eslint clean.

## Verifying in DEV

Per the issue's repro, against a non-production environment — watch `restartCount` while issuing:

```bash
curl -i https://devv2.dmi.voyager.marsvh.com/dmi/auth/callback
```

Expect the same `302 → /ui/login?error=auth_failed` at the client, and **no** restart. Worth also hitting `?code=garbage` and `?state=garbage`, which now take the guarded paths rather than the crash path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)